### PR TITLE
Add utility tests

### DIFF
--- a/src/utils/talks.test.ts
+++ b/src/utils/talks.test.ts
@@ -36,3 +36,118 @@ describe('talks utils', () => {
     });
   });
 }); 
+
+
+import { filterTalks, processTalks } from './talks';
+import type { AirtableItem } from '../hooks/useTalks';
+
+describe('filterTalks', () => {
+  const base: Omit<AirtableItem, 'airtable_id'> & { airtable_id: string } = {
+    airtable_id: '0',
+    name: 'Test',
+    url: 'https://example.com',
+    duration: 10,
+    topics_names: [],
+    speakers_names: [],
+    description: '',
+    core_topic: '',
+    notes: 'notes',
+    language: 'English',
+    rating: 5,
+    resource_type: 'talk',
+    year: 2024,
+    conference_name: 'Conf'
+  } as unknown as AirtableItem;
+
+  const make = (overrides: Partial<AirtableItem>): AirtableItem => ({
+    ...(base as any),
+    ...overrides
+  }) as AirtableItem;
+
+  const sample = [
+    make({ airtable_id: '1' }),
+    make({ airtable_id: '2', language: 'Spanish' as any }),
+    make({ airtable_id: '3', rating: 4 }),
+    make({ airtable_id: '4', resource_type: 'invalid' as any })
+  ];
+
+  it('filters by language and resource type', () => {
+    const result = filterTalks(sample as any, false);
+    expect(result.map(i => i.airtable_id)).toEqual(['1', '3']);
+  });
+
+  it('also filters by rating when enabled', () => {
+    const result = filterTalks(sample as any, true);
+    expect(result.map(i => i.airtable_id)).toEqual(['1']);
+  });
+});
+
+describe('processTalks', () => {
+  const items: AirtableItem[] = [
+    {
+      airtable_id: '1',
+      name: 'Valid',
+      url: 'https://1',
+      duration: 20,
+      topics_names: ['a'],
+      speakers_names: ['s'],
+      description: 'd',
+      core_topic: 'c',
+      notes: '  good  ',
+      language: 'English',
+      rating: 5,
+      resource_type: 'talk',
+      year: 2024,
+      conference_name: 'ConfA'
+    } as unknown as AirtableItem,
+    {
+      airtable_id: '2',
+      name: 'Another',
+      url: 'https://2',
+      duration: 10,
+      topics_names: [],
+      speakers_names: [],
+      description: '',
+      core_topic: '',
+      notes: '   ',
+      language: 'English',
+      rating: 4,
+      resource_type: 'talk',
+      year: 2024,
+      conference_name: 'ConfB'
+    } as unknown as AirtableItem,
+    {
+      airtable_id: '3',
+      name: 'Spanish',
+      url: 'https://3',
+      duration: 5,
+      topics_names: [],
+      speakers_names: [],
+      description: '',
+      core_topic: '',
+      notes: '',
+      language: 'Spanish',
+      rating: 5,
+      resource_type: 'talk',
+      year: 2024,
+      conference_name: 'ConfC'
+    } as unknown as AirtableItem
+  ];
+
+  it('transforms and filters items', () => {
+    const result = processTalks(items as any, false);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      id: '1',
+      title: 'Valid',
+      notes: '  good  '
+    });
+    expect(result[1].notes).toBeUndefined();
+  });
+
+  it('applies rating filter when requested', () => {
+    const result = processTalks(items as any, true);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- expand `talks.test.ts` coverage
- test `filterTalks` filtering logic
- test `processTalks` transformation logic

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a91fc95008323a4f13cd90fc00ee1