### PR TITLE
Add URL support for speaker filter

### DIFF
--- a/src/components/TalksList/TalksList.test.tsx
+++ b/src/components/TalksList/TalksList.test.tsx
@@ -296,4 +296,41 @@ describe('Has Notes Filter', () => {
     expect(button).not.toHaveClass('text-gray-700');
   });
 
-}); 
+});
+
+describe('Author Filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams.clear();
+
+    (useTalks as any).mockImplementation(() => ({
+      talks: [createTalk()],
+      loading: false,
+      error: null
+    }));
+  });
+
+  it('sets author filter and updates URL params', () => {
+    renderWithRouter(<TalksList />);
+
+    const button = screen.getByRole('button', { name: /filter by speaker: Test Speaker/i });
+    fireEvent.click(button);
+
+    expect(mockSetSearchParams).toHaveBeenCalled();
+    const [[params]] = mockSetSearchParams.mock.calls;
+    expect((params as URLSearchParams).get('author')).toBe('Test Speaker');
+  });
+
+  it('removes author filter when clicking the same speaker again', () => {
+    mockSearchParams.set('author', 'Test Speaker');
+
+    renderWithRouter(<TalksList />);
+
+    const button = screen.getByRole('button', { name: /filter by speaker: Test Speaker/i });
+    fireEvent.click(button);
+
+    expect(mockSetSearchParams).toHaveBeenCalled();
+    const [[params]] = mockSetSearchParams.mock.calls;
+    expect((params as URLSearchParams).get('author')).toBeNull();
+  });
+});

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -128,7 +128,24 @@ export function TalksList() {
 
   // Handle author selection
   const handleAuthorClick = (author: string) => {
-    setSelectedAuthor(prev => prev === author ? null : author);
+    const newAuthor = selectedAuthor === author ? null : author;
+    setSelectedAuthor(newAuthor);
+
+    const params = new URLSearchParams();
+
+    // Preserve existing parameters
+    for (const [key, value] of searchParams.entries()) {
+      if (key !== 'author') {
+        params.set(key, value);
+      }
+    }
+
+    // Update author parameter
+    if (newAuthor) {
+      params.set('author', newAuthor);
+    }
+
+    setSearchParams(params);
   };
 
   // Filter talks by selected author, topics, conference, year, and notes


### PR DESCRIPTION
## Summary
- encode selected speaker in URL query parameters
- test for author filter URL behavior

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684aba2c977c83239b9d369c76b46156