### PR TITLE
Fix default rating filter URL sync

### DIFF
--- a/src/components/TalksList/TalksList.test.tsx
+++ b/src/components/TalksList/TalksList.test.tsx
@@ -84,8 +84,8 @@ describe('Author Filter', () => {
     renderWithRouter(<TalksList />);
     const btn = screen.getByRole('button', { name: /filter by speaker: Author A/i });
     fireEvent.click(btn);
-    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
-    const params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(2);
+    const params = mockSetSearchParams.mock.calls[1][0] as URLSearchParams;
     expect(params.get('author')).toBe('Author A');
   });
 
@@ -95,8 +95,8 @@ describe('Author Filter', () => {
     renderWithRouter(<TalksList />);
     const btn = screen.getByRole('button', { name: /filter by speaker: Author B/i });
     fireEvent.click(btn);
-    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
-    const params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(2);
+    const params = mockSetSearchParams.mock.calls[1][0] as URLSearchParams;
     expect(params.get('author')).toBeNull();
   });
   
@@ -134,6 +134,9 @@ describe('Rating Filter', () => {
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('5 Stars');
     expect(button).toHaveClass('bg-blue-500', 'text-white');
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    const params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(params.get('rating')).toBe('5');
   });
 
   it('toggles the rating filter and updates URL params', () => {
@@ -142,8 +145,8 @@ describe('Rating Filter', () => {
     const [toggle] = screen.getAllByRole('button', { name: /toggle rating filter/i });
     // Click to remove rating filter (to show all)
     fireEvent.click(toggle);
-    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
-    let params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(3);
+    let params = mockSetSearchParams.mock.calls[2][0] as URLSearchParams;
     expect(params.get('rating')).toBe('all');
 
     // Simulate URL with rating=all and re-render
@@ -153,8 +156,8 @@ describe('Rating Filter', () => {
     expect(updated).toHaveTextContent('All');
     // Click to enable 5-star filter again
     fireEvent.click(updated);
-    expect(mockSetSearchParams).toHaveBeenCalledTimes(2);
-    params = mockSetSearchParams.mock.calls[1][0] as URLSearchParams;
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(4);
+    params = mockSetSearchParams.mock.calls[3][0] as URLSearchParams;
     expect(params.get('rating')).toBe('5');
   });
 });

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -38,6 +38,15 @@ export function TalksList() {
   // Add scroll position saving
   useScrollPosition();
 
+  // Ensure the URL always includes the rating parameter on first load
+  useEffect(() => {
+    if (!searchParams.get('rating')) {
+      const params = new URLSearchParams(searchParams);
+      params.set('rating', filterByRating ? '5' : 'all');
+      setSearchParams(params);
+    }
+  }, [searchParams, filterByRating]);
+
   // Handle URL parameters and updates
   useEffect(() => {
     const params = new URLSearchParams(searchParams);


### PR DESCRIPTION
## Summary
- sync the rating filter with URL on initial load
- adjust tests for new URL behaviour

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_687605af6d4883238e6377e643ed2810