### PR TITLE
Sync topics and year filters with URL

### DIFF
--- a/src/components/TalksList/TalksList.test.tsx
+++ b/src/components/TalksList/TalksList.test.tsx
@@ -51,7 +51,9 @@ vi.mock('./TalkSection', () => ({
 }));
 
 vi.mock('./YearFilter', () => ({
-  YearFilter: () => <div>Year Filter</div>
+  YearFilter: ({ onFilterChange }: { onFilterChange: any }) => (
+    <button onClick={() => onFilterChange({ type: 'last2' })}>Year Filter</button>
+  )
 }));
 
 // Mock the hooks
@@ -360,5 +362,40 @@ describe('Has Notes Filter', () => {
     expect(button).not.toHaveClass('text-gray-700');
   });
 
+});
+
+describe('URL parameters for other filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams.clear();
+
+    (useTalks as any).mockImplementation(() => ({
+      talks: [
+        createTalk({ id: '1', topics: ['react', 'typescript'] })
+      ],
+      loading: false,
+      error: null
+    }));
+  });
+
+  it('updates topics parameter when selecting topics', () => {
+    renderWithRouter(<TalksList />);
+    const reactBtn = screen.getAllByRole('button', { name: /filter by topic react/i })[0];
+    fireEvent.click(reactBtn);
+    const tsBtn = screen.getAllByRole('button', { name: /filter by topic typescript/i })[0];
+    fireEvent.click(tsBtn);
+
+    const params = mockSetSearchParams.mock.calls[mockSetSearchParams.mock.calls.length - 1][0] as URLSearchParams;
+    expect(params.get('topics')).toBe('react,typescript');
+  });
+
+  it('updates yearType parameter when selecting year filter', () => {
+    renderWithRouter(<TalksList />);
+    const yearButton = screen.getByRole('button', { name: /year filter/i });
+    fireEvent.click(yearButton);
+
+    const params = mockSetSearchParams.mock.calls[mockSetSearchParams.mock.calls.length - 1][0] as URLSearchParams;
+    expect(params.get('yearType')).toBe('last2');
+  });
 });
 

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -119,20 +119,81 @@ export function TalksList() {
     setSearchParams(params);
   };
 
-  // Handle topic selection
+  // Handle topic selection and sync with URL
   const handleTopicClick = (topic: string) => {
     setSelectedTopics(prev => {
       const isSelected = prev.includes(topic);
-      if (isSelected) {
-        return prev.filter(t => t !== topic);
+      const newTopics = isSelected ? prev.filter(t => t !== topic) : [...prev, topic];
+
+      const params = new URLSearchParams();
+      for (const [key, value] of searchParams.entries()) {
+        if (key !== 'topics') {
+          params.set(key, value);
+        }
       }
-      return [...prev, topic];
+
+      if (newTopics.length > 0) {
+        params.set('topics', newTopics.join(','));
+      }
+
+      setSearchParams(params);
+      return newTopics;
     });
   };
 
-  // Handle conference selection
+  const handleClearTopics = () => {
+    setSelectedTopics([]);
+
+    const params = new URLSearchParams();
+    for (const [key, value] of searchParams.entries()) {
+      if (key !== 'topics') {
+        params.set(key, value);
+      }
+    }
+
+    setSearchParams(params);
+  };
+
+  // Handle conference selection and sync with URL
   const handleConferenceClick = (conference: string) => {
-    setSelectedConference(prev => prev === conference ? null : conference);
+    const newConference = selectedConference === conference ? null : conference;
+    setSelectedConference(newConference);
+
+    const params = new URLSearchParams();
+    for (const [key, value] of searchParams.entries()) {
+      if (key !== 'conference') {
+        params.set(key, value);
+      }
+    }
+
+    if (newConference) {
+      params.set('conference', newConference);
+    }
+
+    setSearchParams(params);
+  };
+
+  // Handle year filter change and sync with URL
+  const handleYearFilterChange = (filter: YearFilterData | null) => {
+    setSelectedYearFilter(filter);
+
+    const params = new URLSearchParams();
+    for (const [key, value] of searchParams.entries()) {
+      if (key !== 'yearType' && key !== 'year') {
+        params.set(key, value);
+      }
+    }
+
+    if (filter) {
+      params.set('yearType', filter.type);
+      if (filter.year !== undefined) {
+        params.set('year', filter.year.toString());
+      } else {
+        params.delete('year');
+      }
+    }
+
+    setSearchParams(params);
   };
 
   // Handle author selection by toggling based on current URL param
@@ -237,7 +298,7 @@ export function TalksList() {
         <YearFilter
           talks={talks}
           selectedFilter={selectedYearFilter}
-          onFilterChange={setSelectedYearFilter}
+          onFilterChange={handleYearFilterChange}
         />
         <button
           onClick={handleHasNotesClick}
@@ -309,7 +370,7 @@ export function TalksList() {
               ))}
               <button
                 className="text-sm text-gray-500 hover:text-gray-700"
-                onClick={() => setSelectedTopics([])}
+                onClick={handleClearTopics}
               >
                 Clear all topics
               </button>
@@ -321,7 +382,7 @@ export function TalksList() {
               <span className="text-sm text-gray-500">Year:</span>
               <button
                 className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
-                onClick={() => setSelectedYearFilter(null)}
+                onClick={() => handleYearFilterChange(null)}
               >
                 {selectedYearFilter.type === 'specific' && selectedYearFilter.year ? (
                   selectedYearFilter.year


### PR DESCRIPTION
## Summary
- keep selected topics, year and conference in the query string
- update tests with button-based YearFilter mock
- add tests for topic and year URL parameters

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_687766a2fac0832399f69a850097c2a1