### PR TITLE
Improve scroll position hook coverage

### DIFF
--- a/src/hooks/useScrollPosition.test.tsx
+++ b/src/hooks/useScrollPosition.test.tsx
@@ -247,5 +247,17 @@ describe('useScrollPosition', () => {
       vi.advanceTimersByTime(2000);
       expect(window.scrollTo).toHaveBeenCalledTimes(totalCalls);
     });
+
+    it('ignores invalid saved scroll position', () => {
+      mockStorage.store[SCROLL_INDEX_KEY] = 'not-a-number';
+      const removeSpy = vi.spyOn(mockStorage, 'removeItem');
+
+      renderHook(() => useScrollPosition());
+
+      vi.advanceTimersByTime(100);
+
+      expect(removeSpy).toHaveBeenCalledWith(SCROLL_INDEX_KEY);
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
   });
-}); 
+});


### PR DESCRIPTION
## Summary
- add missing test for invalid scroll position in `useScrollPosition`

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_b_6878d4ba89a883238e43d49bb34788f9