### PR TITLE
Add conference and rating to TalksFilter params

### DIFF
--- a/src/utils/TalksFilter.test.ts
+++ b/src/utils/TalksFilter.test.ts
@@ -58,6 +58,11 @@ describe('TalksFilter', () => {
       const filter = TalksFilter.fromUrlParams('year=2023&query=testing');
       expect(filter.toParams()).toBe('yearType=specific&year=2023&query=testing');
     });
+
+    it('should include conference and rating when present', () => {
+      const filter = TalksFilter.fromUrlParams('conference=ReactConf&rating=4');
+      expect(filter.toParams()).toBe('conference=ReactConf&rating=4');
+    });
   });
 
   describe('filter', () => {
@@ -161,6 +166,9 @@ describe('TalksFilter', () => {
       expect(filter.hasNotes).toBe(true);
       expect(filter.rating).toBe(5);
       expect(filter.query).toBe('testing');
+      const serialized = filter.toParams();
+      expect(serialized).toContain('conference=ReactConf');
+      expect(serialized).toContain('rating=5');
     });
   });
 });

--- a/src/utils/TalksFilter.ts
+++ b/src/utils/TalksFilter.ts
@@ -59,8 +59,14 @@ export class TalksFilter {
     if (this.topics && this.topics.length > 0) {
       params.set('topics', this.topics.join(','));
     }
+    if (this.conference) {
+      params.set('conference', this.conference);
+    }
     if (this.hasNotes) {
       params.set('hasNotes', 'true');
+    }
+    if (this.rating !== null) {
+      params.set('rating', this.rating.toString());
     }
     if (this.query) {
       params.set('query', this.query);


### PR DESCRIPTION
## Summary
- add serialization of conference and rating in `TalksFilter`
- verify conference and rating round trip through `toParams`/`fromUrlParams`

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_687cab2058748323ba481ef851382f4a