### PR TITLE
Add Autocomplete utility class

### DIFF
--- a/src/utils/Autocomplete.test.ts
+++ b/src/utils/Autocomplete.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { Autocomplete } from './Autocomplete';
+import type { Talk } from '../types/talks';
+
+const talks: Talk[] = [
+  {
+    id: '1',
+    title: 'T1',
+    url: '',
+    duration: 0,
+    topics: ['react', 'javascript'],
+    speakers: ['Alice'],
+    description: '',
+    core_topic: ''
+  },
+  {
+    id: '2',
+    title: 'T2',
+    url: '',
+    duration: 0,
+    topics: ['testing', 'javascript'],
+    speakers: ['Bob'],
+    description: '',
+    core_topic: ''
+  },
+  {
+    id: '3',
+    title: 'T3',
+    url: '',
+    duration: 0,
+    topics: ['react'],
+    speakers: ['Alice', 'Carol'],
+    description: '',
+    core_topic: ''
+  }
+];
+
+describe('Autocomplete', () => {
+  const ac = new Autocomplete(talks);
+
+  it('suggests topics matching query case-insensitively', () => {
+    expect(ac.autocompleteTopics('re')).toEqual(['react']);
+    expect(ac.autocompleteTopics('JAV')).toEqual(['javascript']);
+  });
+
+  it('deduplicates topics', () => {
+    expect(ac.autocompleteTopics('')).toEqual(['javascript', 'react', 'testing']);
+  });
+
+  it('suggests speakers matching query case-insensitively', () => {
+    expect(ac.autocompleteSpeakers('al')).toEqual(['Alice']);
+    expect(ac.autocompleteSpeakers('b')).toEqual(['Bob']);
+  });
+
+  it('deduplicates speakers', () => {
+    expect(ac.autocompleteSpeakers('')).toEqual(['Alice', 'Bob', 'Carol']);
+  });
+});

--- a/src/utils/Autocomplete.ts
+++ b/src/utils/Autocomplete.ts
@@ -1,0 +1,33 @@
+import type { Talk } from '../types/talks';
+
+export class Autocomplete {
+  private topics: string[];
+  private speakers: string[];
+
+  constructor(talks: Talk[]) {
+    const topicSet = new Set<string>();
+    const speakerSet = new Set<string>();
+
+    for (const talk of talks) {
+      for (const topic of talk.topics) {
+        topicSet.add(topic);
+      }
+      for (const speaker of talk.speakers) {
+        speakerSet.add(speaker);
+      }
+    }
+
+    this.topics = Array.from(topicSet).sort();
+    this.speakers = Array.from(speakerSet).sort();
+  }
+
+  autocompleteTopics(query: string): string[] {
+    const normalized = query.toLowerCase();
+    return this.topics.filter(t => t.toLowerCase().includes(normalized));
+  }
+
+  autocompleteSpeakers(query: string): string[] {
+    const normalized = query.toLowerCase();
+    return this.speakers.filter(s => s.toLowerCase().includes(normalized));
+  }
+}


### PR DESCRIPTION
## Summary
- add `Autocomplete` class for topics and speakers
- test the new class

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68854e7108f883239889f582f190bf89