### PR TITLE
Add search box with autocomplete

### DIFF
--- a/src/components/SearchBox/SearchBox.test.tsx
+++ b/src/components/SearchBox/SearchBox.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { renderWithRouter, mockSetSearchParams, createTalk } from '../../test/utils';
+import { SearchBox } from './index';
+
+const talks = [
+  createTalk({ speakers: ['Alice'], topics: ['react'] }),
+  createTalk({ speakers: ['Bob'], topics: ['javascript'] }),
+];
+
+describe('SearchBox', () => {
+  it('suggests topics based on input', () => {
+    renderWithRouter(<SearchBox talks={talks} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'topic:r' } });
+    expect(screen.getByText('react')).toBeInTheDocument();
+  });
+
+  it('updates url params on submit', async () => {
+    renderWithRouter(<SearchBox talks={talks} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'author:Alice topic:react' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(mockSetSearchParams).toHaveBeenCalled());
+    const params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(params.get('author')).toBe('Alice');
+    expect(params.get('topics')).toBe('react');
+  });
+});

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { Talk } from '../../types/talks';
+import { Autocomplete } from '../../utils/Autocomplete';
+import { parseSearch } from '../../utils/SearchParser';
+import { TalksFilter } from '../../utils/TalksFilter';
+
+interface SearchBoxProps {
+  talks: Talk[];
+}
+
+export function SearchBox({ talks }: SearchBoxProps) {
+  const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = useMemo(() => TalksFilter.fromUrlParams(searchParams), [searchParams.toString()]);
+  const ac = useMemo(() => new Autocomplete(talks), [talks]);
+
+  const updateSuggestions = (text: string) => {
+    const parts = text.split(/\s+/);
+    const last = parts[parts.length - 1];
+    if (last.toLowerCase().startsWith('author:')) {
+      setSuggestions(ac.autocompleteSpeakers(last.slice('author:'.length)));
+    } else if (last.toLowerCase().startsWith('topic:')) {
+      setSuggestions(ac.autocompleteTopics(last.slice('topic:'.length)));
+    } else {
+      setSuggestions([]);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setValue(newValue);
+    updateSuggestions(newValue);
+  };
+
+  const handleSuggestionClick = (s: string) => {
+    const parts = value.split(/\s+/);
+    const last = parts[parts.length - 1];
+    if (last.toLowerCase().startsWith('author:')) {
+      parts[parts.length - 1] = 'author:' + s;
+    } else if (last.toLowerCase().startsWith('topic:')) {
+      parts[parts.length - 1] = 'topic:' + s;
+    }
+    const newValue = parts.join(' ');
+    setValue(newValue);
+    setSuggestions([]);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSubmit(e as unknown as React.FormEvent);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = parseSearch(value);
+    const nextFilter = new TalksFilter({
+      ...filter,
+      author: parsed.author,
+      topics: parsed.topics,
+      query: parsed.query,
+    });
+
+    const next = new URLSearchParams(nextFilter.toParams());
+    for (const [key, val] of searchParams.entries()) {
+      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
+        next.set(key, val);
+      }
+    }
+    setSearchParams(next);
+    setSuggestions([]);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="relative" data-testid="search-form">
+      <input
+        type="text"
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className="w-full border rounded px-3 py-2"
+        placeholder="Search (author:Alice topic:react)"
+      />
+      {suggestions.length > 0 && (
+        <ul className="absolute z-10 bg-white border w-full mt-1 max-h-40 overflow-auto">
+          {suggestions.map(s => (
+            <li key={s}>
+              <button
+                type="button"
+                className="block w-full text-left px-3 py-1 hover:bg-gray-100"
+                onClick={() => handleSuggestionClick(s)}
+              >
+                {s}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </form>
+  );
+}

--- a/src/utils/SearchParser.test.ts
+++ b/src/utils/SearchParser.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { parseSearch } from './SearchParser';
+
+describe('parseSearch', () => {
+  it('parses author token', () => {
+    const result = parseSearch('author:Alice');
+    expect(result.author).toBe('Alice');
+    expect(result.topics).toEqual([]);
+    expect(result.query).toBe('');
+  });
+
+  it('parses multiple topics', () => {
+    const result = parseSearch('topic:react topic:testing');
+    expect(result.author).toBeNull();
+    expect(result.topics).toEqual(['react', 'testing']);
+  });
+
+  it('parses mix of tokens and query text', () => {
+    const result = parseSearch('author:Bob cool talk topic:javascript');
+    expect(result.author).toBe('Bob');
+    expect(result.topics).toEqual(['javascript']);
+    expect(result.query).toBe('cool talk');
+  });
+});

--- a/src/utils/SearchParser.ts
+++ b/src/utils/SearchParser.ts
@@ -1,0 +1,26 @@
+export interface ParsedSearch {
+  author: string | null;
+  topics: string[];
+  query: string;
+}
+
+export function parseSearch(input: string): ParsedSearch {
+  const tokens = input.trim().split(/\s+/).filter(Boolean);
+  let author: string | null = null;
+  const topics: string[] = [];
+  const queryParts: string[] = [];
+
+  for (const token of tokens) {
+    if (token.toLowerCase().startsWith('author:')) {
+      const value = token.slice('author:'.length);
+      if (value) author = value;
+    } else if (token.toLowerCase().startsWith('topic:')) {
+      const value = token.slice('topic:'.length);
+      if (value) topics.push(value);
+    } else {
+      queryParts.push(token);
+    }
+  }
+
+  return { author, topics, query: queryParts.join(' ') };
+}


### PR DESCRIPTION
## Summary
- implement a small DSL parser to read `author:` and `topic:` tokens
- add `SearchBox` component using the `Autocomplete` class
- provide tests for parsing and search box behavior

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_6885d8cd44288323940e62518ab90c33