### PR TITLE
Fix incorrect year filter reset

### DIFF
--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { Talk } from '../../types/talks';
 import { TalkSection } from './TalkSection';
 import { useTalks } from '../../hooks/useTalks';
 import { YearFilter, type YearFilterData } from './YearFilter';
-import { useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useScrollPosition } from '../../hooks/useScrollPosition';
 import { hasMeaningfulNotes } from '../../utils/talks';
 import { DocumentTextIcon, StarIcon } from '@heroicons/react/24/outline';
@@ -27,7 +27,6 @@ function ErrorMessage({ message }: { message: string }) {
 }
 
 export function TalksList() {
-  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const filter = useMemo(() => {
     return TalksFilter.fromUrlParams(searchParams);
@@ -38,41 +37,7 @@ export function TalksList() {
   // Add scroll position saving
   useScrollPosition();
 
-  // Handle URL parameters and updates
-  useEffect(() => {
-    const params = new URLSearchParams(searchParams);
-    const author = params.get('author');
-    const topics = params.get('topics')?.split(',').filter(Boolean) || [];
-    const conference = params.get('conference');
-    const year = params.get('year');
-    const yearType = params.get('yearType');
-    const hasNotes = params.get('hasNotes') === 'true';
-    const rating = params.get('rating');
-    
-    // Update state from URL
-    // setSelectedAuthor(author); // This line was removed as per the edit hint
-    if (topics.length > 0) {
-      // The selectedTopics state is removed, so we directly update the filter
-      const nextFilter = new TalksFilter({
-        year: filter.year,
-        author: filter.author,
-        topics: topics,
-        conference: filter.conference,
-        hasNotes: filter.hasNotes,
-        rating: filter.rating,
-        query: filter.query,
-      });
-      setSearchParams(nextFilter.toParams());
-    }
-    if (conference) {
-      const nextFilter = new TalksFilter({
-        ...filter,
-        conference: conference,
-      });
-      setSearchParams(nextFilter.toParams());
-    }
-    // No local state for year filter; handled by TalksFilter
-  }, [searchParams, filter]);
+
 
   // Update URL when filters change
   const handleHasNotesClick = () => {

--- a/src/utils/TalksFilter.test.ts
+++ b/src/utils/TalksFilter.test.ts
@@ -105,6 +105,34 @@ describe('TalksFilter', () => {
       const filter = TalksFilter.fromUrlParams('query=TESTING');
       expect(filter.filter(talks)).toEqual([talkWithTesting]);
     });
+
+    it('should filter by author', () => {
+      const talkAlice = { id: '4', title: 'By Alice', year: 2024, url: '', duration: 0, topics: [], speakers: ['Alice'], description: '', core_topic: '', conference_name: 'ConfA', notes: 'n' };
+      const talkBob = { id: '5', title: 'By Bob', year: 2024, url: '', duration: 0, topics: [], speakers: ['Bob'], description: '', core_topic: '', conference_name: 'ConfB' };
+      const filter = TalksFilter.fromUrlParams('author=Alice');
+      expect(filter.filter([talkAlice, talkBob])).toEqual([talkAlice]);
+    });
+
+    it('should filter by topics (AND condition)', () => {
+      const talkReactTs = { id: '6', title: 'React TS', year: 2024, url: '', duration: 0, topics: ['react','typescript'], speakers: [], description: '', core_topic: '' };
+      const talkReact = { id: '7', title: 'React', year: 2024, url: '', duration: 0, topics: ['react'], speakers: [], description: '', core_topic: '' };
+      const filter = TalksFilter.fromUrlParams('topics=react,typescript');
+      expect(filter.filter([talkReactTs, talkReact])).toEqual([talkReactTs]);
+    });
+
+    it('should filter by conference', () => {
+      const t1 = { id: '8', title: 'A', year: 2024, url: '', duration: 0, topics: [], speakers: [], description: '', core_topic: '', conference_name: 'ConfA' };
+      const t2 = { id: '9', title: 'B', year: 2024, url: '', duration: 0, topics: [], speakers: [], description: '', core_topic: '', conference_name: 'ConfB' };
+      const filter = TalksFilter.fromUrlParams('conference=ConfA');
+      expect(filter.filter([t1, t2])).toEqual([t1]);
+    });
+
+    it('should filter by hasNotes', () => {
+      const withNotes = { id: '10', title: 'Notes', year: 2024, url: '', duration: 0, topics: [], speakers: [], description: '', core_topic: '', notes: 'some' };
+      const withoutNotes = { id: '11', title: 'No', year: 2024, url: '', duration: 0, topics: [], speakers: [], description: '', core_topic: '', notes: '' };
+      const filter = TalksFilter.fromUrlParams('hasNotes=true');
+      expect(filter.filter([withNotes, withoutNotes])).toEqual([withNotes]);
+    });
   });
 
   describe('year filter types', () => {

--- a/src/utils/TalksFilter.ts
+++ b/src/utils/TalksFilter.ts
@@ -1,4 +1,5 @@
 import { Talk } from "../types/talks";
+import { hasMeaningfulNotes } from "./talks";
 
 export class TalksFilter {
   readonly year: number | null;
@@ -101,7 +102,11 @@ export class TalksFilter {
         }
       }
       const queryMatch = !this.query || talk.title.toLowerCase().includes(this.query.toLowerCase());
-      return yearMatch && queryMatch;
+      const authorMatch = !this.author || talk.speakers.includes(this.author);
+      const topicsMatch = this.topics.length === 0 || this.topics.every(t => talk.topics.includes(t));
+      const conferenceMatch = !this.conference || talk.conference_name === this.conference;
+      const notesMatch = !this.hasNotes || hasMeaningfulNotes(talk.notes);
+      return yearMatch && queryMatch && authorMatch && topicsMatch && conferenceMatch && notesMatch;
     });
   }
 


### PR DESCRIPTION
## Summary
- remove leftover searchParams sync effect in TalksList
- extend TalksFilter to handle more filters
- test author/topic/conference/notes filtering

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_6885ec41d60083239b046d624b72956a