### PR TITLE
Fix talk card overflow and responsive grid

### DIFF
--- a/src/components/TalksList/TalkCard.tsx
+++ b/src/components/TalksList/TalkCard.tsx
@@ -28,25 +28,27 @@ export function TalkCard({
   const [searchParams] = useSearchParams();
 
   // Memoize topics to avoid unnecessary re-renders
-  const topicElements = useMemo(() => (
-    talk.topics.map((topic) => (
-      <button
-        key={topic}
-        onClick={(e) => {
-          e.stopPropagation(); // Prevent card click
-          onTopicClick(topic);
-        }}
-        aria-label={`Filter by topic ${topic}`}
-        className={`px-2 py-1 rounded-full text-xs transition-colors ${
-          selectedTopics.includes(topic)
-            ? 'bg-gray-700 text-white'
-            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-        }`}
-      >
-        {topic}
-      </button>
-    ))
-  ), [talk.topics, onTopicClick, selectedTopics]);
+  const topicElements = useMemo(
+    () =>
+      talk.topics.map((topic) => (
+        <button
+          key={topic}
+          onClick={(e) => {
+            e.stopPropagation(); // Prevent card click
+            onTopicClick(topic);
+          }}
+          aria-label={`Filter by topic ${topic}`}
+          className={`break-words px-2 py-1 rounded-full text-xs transition-colors ${
+            selectedTopics.includes(topic)
+              ? 'bg-gray-700 text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          {topic}
+        </button>
+      )),
+    [talk.topics, onTopicClick, selectedTopics]
+  );
 
   const handleCardClick = () => {
     // Navigate to talk detail
@@ -57,13 +59,13 @@ export function TalkCard({
   };
 
   return (
-    <div 
+    <div
       onClick={handleCardClick}
       onKeyDown={(e) => e.key === 'Enter' && handleCardClick()}
       role="article"
       tabIndex={0}
       aria-label={`Talk: ${talk.title}`}
-      className="block bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow cursor-pointer"
+      className="block w-full bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow cursor-pointer"
     >
       <div className="p-6 flex flex-col h-full">
         <div className="flex-1">
@@ -93,7 +95,7 @@ export function TalkCard({
                   onAuthorClick(speaker);
                 }}
                 aria-label={`Filter by speaker: ${speaker}`}
-                className={`px-2 py-1 rounded-full text-xs transition-colors ${
+                className={`break-words px-2 py-1 rounded-full text-xs transition-colors ${
                   selectedAuthor === speaker
                     ? 'bg-blue-500 text-white'
                     : 'bg-blue-50 text-blue-700 hover:bg-blue-100'
@@ -115,7 +117,7 @@ export function TalkCard({
                     onConferenceClick(talk.conference_name!);
                   }}
                   aria-label={`Filter by conference ${talk.conference_name}`}
-                  className={`px-2 py-1 rounded-full text-xs transition-colors ${
+                  className={`break-words px-2 py-1 rounded-full text-xs transition-colors ${
                     selectedConference === talk.conference_name
                       ? 'bg-blue-500 text-white'
                       : 'bg-blue-50 text-blue-700 hover:bg-blue-100'

--- a/src/components/TalksList/TalkSection.tsx
+++ b/src/components/TalksList/TalkSection.tsx
@@ -27,7 +27,7 @@ export function TalkSection({
       <h2 className="text-2xl font-bold text-gray-900 mb-6">
         {coreTopic} <span className="text-gray-500">({talks.length})</span>
       </h2>
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+      <div className="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {talks.map((talk) => (
           <TalkCard 
             key={talk.id} 

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -295,7 +295,7 @@ export function TalksList() {
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-500">Speaker:</span>
               <button
-                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
+                className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
                 onClick={() => handleAuthorClick(filter.author!)}
               >
                 {filter.author}
@@ -308,7 +308,7 @@ export function TalksList() {
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-500">Conference:</span>
               <button
-                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
+                className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
                 onClick={() => handleConferenceClick(filter.conference!)}
               >
                 {filter.conference}
@@ -323,7 +323,7 @@ export function TalksList() {
               {filter.topics.map(topic => (
                 <button
                   key={topic}
-                  className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-gray-100 text-gray-800"
+                  className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-gray-100 text-gray-800"
                   onClick={() => handleTopicClick(topic)}
                 >
                   {topic}
@@ -343,7 +343,7 @@ export function TalksList() {
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-500">Year:</span>
               <button
-                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
+                className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
                 onClick={() => handleYearFilterChange(null)}
               >
                 {yearFilter.type === 'specific' && yearFilter.year ? (
@@ -366,7 +366,7 @@ export function TalksList() {
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-500">Filter:</span>
               <button
-                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
+                className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
                 onClick={handleHasNotesClick}
                 aria-label="Remove Has Notes filter"
               >
@@ -380,7 +380,7 @@ export function TalksList() {
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-500">Filter:</span>
               <button
-                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
+                className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
                 onClick={handleRatingClick}
                 aria-label="Remove Rating filter"
               >


### PR DESCRIPTION
## Summary
- update `TalkSection` grid to avoid overflow on large screens
- make `TalkCard` stretch to available width and wrap long labels
- wrap long filter tags on the list page

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_b_6885f704ab5883238b49e979a42ec20d