### PR TITLE
Add edge case tests for SearchParser tokens

### DIFF
--- a/src/utils/SearchParser.test.ts
+++ b/src/utils/SearchParser.test.ts
@@ -42,4 +42,18 @@ describe('parseSearch', () => {
     expect(result.topics).toEqual(['unit testing']);
     expect(result.query).toBe('');
   });
+
+  it('gracefully handles empty author token', () => {
+    const result = parseSearch('author:   ');
+    expect(result.author).toBeNull();
+    expect(result.topics).toEqual([]);
+    expect(result.query).toBe('');
+  });
+
+  it('gracefully handles empty topic token', () => {
+    const result = parseSearch('topic:  ');
+    expect(result.author).toBeNull();
+    expect(result.topics).toEqual([]);
+    expect(result.query).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- increase coverage by testing empty author/topic tokens in SearchParser

## Testing
- `npm test -- --run`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_b_6885f844f97483239a15d19adde30a33