### PR TITLE
Add topics filter component

### DIFF
--- a/src/components/TalksList/TopicsFilter.test.tsx
+++ b/src/components/TalksList/TopicsFilter.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TopicsFilter } from './TopicsFilter';
+import { createTalk, renderWithRouter } from '../../test/utils';
+
+const openMenu = () => {
+  const button = screen.getByRole('button');
+  fireEvent.click(button);
+};
+
+describe('TopicsFilter', () => {
+  it('renders unique topics in alphabetical order', () => {
+    const talks = [
+      createTalk({ topics: ['b'] }),
+      createTalk({ topics: ['a', 'c'] }),
+    ];
+
+    renderWithRouter(
+      <TopicsFilter talks={talks} selectedTopics={[]} onChange={() => {}} />
+    );
+
+    openMenu();
+
+    const items = screen.getAllByRole('menuitem');
+    const topics = items.map(btn => btn.textContent);
+    expect(topics).toEqual(['a', 'b', 'c']);
+  });
+
+  it('calls onChange with updated topics', () => {
+    const talks = [createTalk({ topics: ['react'] })];
+    const onChange = vi.fn();
+    renderWithRouter(
+      <TopicsFilter talks={talks} selectedTopics={[]} onChange={onChange} />
+    );
+    openMenu();
+    fireEvent.click(screen.getByText('react'));
+    expect(onChange).toHaveBeenCalledWith(['react']);
+  });
+
+  it('shows count of selected topics', () => {
+    const talks = [createTalk({ topics: ['a'] })];
+    renderWithRouter(
+      <TopicsFilter talks={talks} selectedTopics={['a', 'b']} onChange={() => {}} />
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('Topics (2)');
+  });
+
+  it('toggles off a selected topic', () => {
+    const talks = [createTalk({ topics: ['react'] })];
+    const onChange = vi.fn();
+    renderWithRouter(
+      <TopicsFilter talks={talks} selectedTopics={['react']} onChange={onChange} />
+    );
+    openMenu();
+    fireEvent.click(screen.getByText('react'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('clears all topics when clicking Clear All', () => {
+    const talks = [createTalk({ topics: ['a', 'b'] })];
+    const onChange = vi.fn();
+    renderWithRouter(
+      <TopicsFilter talks={talks} selectedTopics={['a', 'b']} onChange={onChange} />
+    );
+    openMenu();
+    fireEvent.click(screen.getByText('Clear All'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/TalksList/TopicsFilter.tsx
+++ b/src/components/TalksList/TopicsFilter.tsx
@@ -1,0 +1,96 @@
+import { Fragment, useMemo } from 'react';
+import { Menu, Transition } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import { Talk } from '../../types/talks';
+
+interface TopicsFilterProps {
+  talks: Talk[];
+  selectedTopics: string[];
+  onChange: (topics: string[]) => void;
+}
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export function TopicsFilter({ talks, selectedTopics, onChange }: TopicsFilterProps) {
+  const availableTopics = useMemo(() => {
+    const set = new Set<string>();
+    talks.forEach(t => {
+      t.topics.forEach(topic => set.add(topic));
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [talks]);
+
+  const toggleTopic = (topic: string) => {
+    const isSelected = selectedTopics.includes(topic);
+    const newTopics = isSelected
+      ? selectedTopics.filter(t => t !== topic)
+      : [...selectedTopics, topic];
+    onChange(newTopics);
+  };
+
+  const label = selectedTopics.length > 0 ? `Topics (${selectedTopics.length})` : 'Topics';
+
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      <div>
+        <Menu.Button className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          {label}
+          <ChevronDownIcon className="-mr-1 h-5 w-5 text-gray-400" aria-hidden="true" />
+        </Menu.Button>
+      </div>
+
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items className="absolute left-0 z-50 mt-2 w-56 origin-top-left divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none max-h-60 overflow-y-auto">
+          <div className="py-1">
+            {availableTopics.map(topic => (
+              <Menu.Item key={topic}>
+                {({ active }: { active: boolean }) => (
+                  <button
+                    onClick={() => toggleTopic(topic)}
+                    className={classNames(
+                      selectedTopics.includes(topic)
+                        ? 'bg-blue-100 text-blue-800'
+                        : active
+                        ? 'bg-gray-100 text-gray-900'
+                        : 'text-gray-700',
+                      'block w-full px-4 py-2 text-left text-sm'
+                    )}
+                  >
+                    {topic}
+                  </button>
+                )}
+              </Menu.Item>
+            ))}
+          </div>
+          {selectedTopics.length > 0 && (
+            <div className="py-1">
+              <Menu.Item>
+                {({ active }: { active: boolean }) => (
+                  <button
+                    onClick={() => onChange([])}
+                    className={classNames(
+                      active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                      'block w-full px-4 py-2 text-left text-sm'
+                    )}
+                  >
+                    Clear All
+                  </button>
+                )}
+              </Menu.Item>
+            </div>
+          )}
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+}

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -9,6 +9,7 @@ import { hasMeaningfulNotes } from '../../utils/talks';
 import { DocumentTextIcon, StarIcon } from '@heroicons/react/24/outline';
 import { TalksFilter } from '../../utils/TalksFilter';
 import { SearchBox } from '../SearchBox';
+import { TopicsFilter } from './TopicsFilter';
 
 function LoadingSpinner() {
   return (
@@ -74,26 +75,11 @@ export function TalksList() {
     setSearchParams(next);
   };
 
-  // Handle topic selection and sync with URL
-  const handleTopicClick = (topic: string) => {
-    const urlTopics = (searchParams.get('topics')?.split(',').filter(Boolean)) || [];
-    const isSelected = urlTopics.includes(topic);
-    let newTopics;
-    if (isSelected) {
-      newTopics = urlTopics.filter(t => t !== topic);
-    } else {
-      newTopics = [...urlTopics, topic];
-    }
+  const updateTopics = (topics: string[]) => {
     const nextFilter = new TalksFilter({
-      year: filter.year,
-      author: filter.author,
-      topics: newTopics,
-      conference: filter.conference,
-      hasNotes: filter.hasNotes,
-      rating: filter.rating,
-      query: filter.query,
+      ...filter,
+      topics
     });
-    // Preserve extra params
     const current = new URLSearchParams(searchParams);
     const next = new URLSearchParams(nextFilter.toParams());
     for (const [key, value] of current.entries()) {
@@ -104,25 +90,18 @@ export function TalksList() {
     setSearchParams(next);
   };
 
+  const handleTopicClick = (topic: string) => {
+    const isSelected = filter.topics.includes(topic);
+    const newTopics = isSelected ? filter.topics.filter(t => t !== topic) : [...filter.topics, topic];
+    updateTopics(newTopics);
+  };
+
   const handleClearTopics = () => {
-    const nextFilter = new TalksFilter({
-      year: filter.year,
-      author: filter.author,
-      topics: [],
-      conference: filter.conference,
-      hasNotes: filter.hasNotes,
-      rating: filter.rating,
-      query: filter.query,
-    });
-    // Preserve extra params
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, value);
-      }
-    }
-    setSearchParams(next);
+    updateTopics([]);
+  };
+
+  const handleTopicsChange = (topics: string[]) => {
+    updateTopics(topics);
   };
 
   // Handle conference selection and sync with URL using TalksFilter
@@ -261,6 +240,11 @@ export function TalksList() {
           talks={talks}
           selectedFilter={yearFilter}
           onFilterChange={handleYearFilterChange}
+        />
+        <TopicsFilter
+          talks={talks || []}
+          selectedTopics={filter.topics}
+          onChange={handleTopicsChange}
         />
         <button
           onClick={handleHasNotesClick}


### PR DESCRIPTION
## Summary
- add new `TopicsFilter` component with multi-select dropdown
- integrate topics filter in `TalksList`
- test the new component
- increase coverage for `TopicsFilter` by testing toggling and clearing

## Testing
- `npm test -- --run`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_b_6885f924ae388323b3d46cb4b39d57a0