### PR TITLE
Add format filter with icons

### DIFF
--- a/src/components/TalksList/FormatFilter.test.tsx
+++ b/src/components/TalksList/FormatFilter.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FormatFilter } from './FormatFilter';
+import { renderWithRouter } from '../../test/utils';
+
+describe('FormatFilter', () => {
+  it('renders checkboxes for talks and podcasts', () => {
+    renderWithRouter(
+      <FormatFilter selectedFormats={[]} onChange={() => {}} />
+    );
+    expect(screen.getByLabelText(/talks/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/podcasts/i)).toBeInTheDocument();
+  });
+
+  it('toggles formats and calls onChange', () => {
+    const onChange = vi.fn();
+    renderWithRouter(
+      <FormatFilter selectedFormats={['talk']} onChange={onChange} />
+    );
+    const podcasts = screen.getByLabelText(/podcasts/i);
+    fireEvent.click(podcasts);
+    expect(onChange).toHaveBeenCalledWith(['talk', 'podcast']);
+  });
+});

--- a/src/components/TalksList/FormatFilter.tsx
+++ b/src/components/TalksList/FormatFilter.tsx
@@ -1,0 +1,38 @@
+import { VideoCameraIcon, MicrophoneIcon } from '@heroicons/react/24/outline';
+
+interface FormatFilterProps {
+  selectedFormats: string[];
+  onChange: (formats: string[]) => void;
+}
+
+export function FormatFilter({ selectedFormats, onChange }: FormatFilterProps) {
+  const toggle = (fmt: string) => {
+    const newFormats = selectedFormats.includes(fmt)
+      ? selectedFormats.filter(f => f !== fmt)
+      : [...selectedFormats, fmt];
+    onChange(newFormats);
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      <label className="inline-flex items-center gap-1 text-sm">
+        <input
+          type="checkbox"
+          checked={selectedFormats.includes('talk')}
+          onChange={() => toggle('talk')}
+          aria-label="Talks"
+        />
+        <VideoCameraIcon className="h-4 w-4" aria-hidden="true" /> Talks
+      </label>
+      <label className="inline-flex items-center gap-1 text-sm">
+        <input
+          type="checkbox"
+          checked={selectedFormats.includes('podcast')}
+          onChange={() => toggle('podcast')}
+          aria-label="Podcasts"
+        />
+        <MicrophoneIcon className="h-4 w-4" aria-hidden="true" /> Podcasts
+      </label>
+    </div>
+  );
+}

--- a/src/components/TalksList/TalkCard.test.tsx
+++ b/src/components/TalksList/TalkCard.test.tsx
@@ -75,6 +75,12 @@ describe('TalkCard', () => {
       });
     });
 
+    it('shows format icon based on talk format', () => {
+      const talk = createTalk({ format: 'podcast' });
+      renderTalkCard({ talk });
+      expect(screen.getByLabelText(/format: podcast/i)).toBeInTheDocument();
+    });
+
     it('has correct watch talk link', () => {
       const talk = createTalk({
         title: 'Test Talk',

--- a/src/components/TalksList/TalkCard.tsx
+++ b/src/components/TalksList/TalkCard.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Talk } from '../../types/talks';
 import { formatDuration } from '../../utils/format';
 import { hasMeaningfulNotes } from '../../utils/talks';
-import { DocumentTextIcon, PlayIcon } from '@heroicons/react/24/outline';
+import { DocumentTextIcon, PlayIcon, VideoCameraIcon, MicrophoneIcon } from '@heroicons/react/24/outline';
 
 interface TalkCardProps {
   talk: Talk;
@@ -73,18 +73,25 @@ export function TalkCard({
             <h3 className="text-lg font-semibold text-gray-900">
               {talk.title}
             </h3>
-            {hasMeaningfulNotes(talk.notes) && (
-              <span
-                role="img"
-                aria-label="This talk has detailed notes"
-                title="This talk has detailed notes"
-              >
-                <DocumentTextIcon 
-                  className="h-5 w-5 text-blue-500 flex-shrink-0 ml-2" 
-                  aria-hidden="true"
-                />
-              </span>
-            )}
+            <div className="flex items-center gap-1">
+              {hasMeaningfulNotes(talk.notes) && (
+                <span
+                  role="img"
+                  aria-label="This talk has detailed notes"
+                  title="This talk has detailed notes"
+                >
+                  <DocumentTextIcon
+                    className="h-5 w-5 text-blue-500 flex-shrink-0 ml-2"
+                    aria-hidden="true"
+                  />
+                </span>
+              )}
+              {talk.format === 'podcast' ? (
+                <MicrophoneIcon className="h-5 w-5 text-gray-500" aria-label="Format: Podcast" />
+              ) : (
+                <VideoCameraIcon className="h-5 w-5 text-gray-500" aria-label="Format: Talk" />
+              )}
+            </div>
           </div>
           <div className="flex flex-wrap gap-2 mb-3">
             {talk.speakers.map((speaker) => (

--- a/src/components/TalksList/TalksList.test.tsx
+++ b/src/components/TalksList/TalksList.test.tsx
@@ -173,6 +173,29 @@ describe('Rating Filter', () => {
   });
 });
 
+describe('Format Filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockSearchParams(new URLSearchParams());
+    (useTalks as any).mockImplementation(() => ({
+      talks: [
+        createTalk({ id: '1', format: 'talk' }),
+        createTalk({ id: '2', format: 'podcast' })
+      ],
+      loading: false,
+      error: null
+    }));
+  });
+
+  it('updates format parameter when toggling checkboxes', () => {
+    renderWithRouter(<TalksList />);
+    const podcastBox = screen.getByLabelText(/podcasts/i);
+    fireEvent.click(podcastBox);
+    const params = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(params.get('format')).toBe('podcast');
+  });
+});
+
 // Mock the hasMeaningfulNotes function
 vi.mock('../../utils/talks', () => ({
   hasMeaningfulNotes: (notes: string | undefined) => {

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -10,6 +10,7 @@ import { DocumentTextIcon, StarIcon } from '@heroicons/react/24/outline';
 import { TalksFilter } from '../../utils/TalksFilter';
 import { SearchBox } from '../SearchBox';
 import { TopicsFilter } from './TopicsFilter';
+import { FormatFilter } from './FormatFilter';
 
 function LoadingSpinner() {
   return (
@@ -84,6 +85,21 @@ export function TalksList() {
     const next = new URLSearchParams(nextFilter.toParams());
     for (const [key, value] of current.entries()) {
       if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
+        next.set(key, value);
+      }
+    }
+    setSearchParams(next);
+  };
+
+  const handleFormatChange = (formats: string[]) => {
+    const nextFilter = new TalksFilter({
+      ...filter,
+      formats,
+    });
+    const current = new URLSearchParams(searchParams);
+    const next = new URLSearchParams(nextFilter.toParams());
+    for (const [key, value] of current.entries()) {
+      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query','format'].includes(key)) {
         next.set(key, value);
       }
     }
@@ -246,6 +262,7 @@ export function TalksList() {
           selectedTopics={filter.topics}
           onChange={handleTopicsChange}
         />
+        <FormatFilter selectedFormats={filter.formats} onChange={handleFormatChange} />
         <button
           onClick={handleHasNotesClick}
           aria-label="Toggle Has Notes filter"
@@ -273,7 +290,7 @@ export function TalksList() {
       </div>
 
       {/* Active filters */}
-      {(filter.author || filter.topics.length > 0 || filter.conference || yearFilter || filter.hasNotes || filter.rating === 5) && (
+      {(filter.author || filter.topics.length > 0 || filter.conference || yearFilter || filter.hasNotes || filter.rating === 5 || filter.formats.length > 0) && (
         <div className="mb-6 space-y-3">
           {filter.author && (
             <div className="flex items-center gap-2">
@@ -371,6 +388,22 @@ export function TalksList() {
                 5 Stars
                 <span className="ml-2 text-blue-600" aria-hidden="true">×</span>
               </button>
+            </div>
+          )}
+
+          {filter.formats.length > 0 && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-500">Format:</span>
+              {filter.formats.map(fmt => (
+                <button
+                  key={fmt}
+                  className="break-words inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
+                  onClick={() => handleFormatChange(filter.formats.filter(f => f !== fmt))}
+                >
+                  {fmt.charAt(0).toUpperCase() + fmt.slice(1)}
+                  <span className="ml-2 text-blue-600">×</span>
+                </button>
+              ))}
             </div>
           )}
         </div>

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -63,7 +63,8 @@ export const mockTalk: Talk = {
   core_topic: 'test',
   url: 'https://example.com',
   description: 'Test description',
-  notes: undefined
+  notes: undefined,
+  format: 'talk'
 };
 
 // Types for mock handlers

--- a/src/types/talks.ts
+++ b/src/types/talks.ts
@@ -10,4 +10,5 @@ export interface Talk {
   notes?: string;  // Optional field for rich text notes
   year?: number;  // Optional field for the talk's year
   conference_name?: string;  // Optional field for conference name
-} 
+  format?: 'talk' | 'podcast' | 'article';
+}

--- a/src/utils/TalksFilter.test.ts
+++ b/src/utils/TalksFilter.test.ts
@@ -133,6 +133,14 @@ describe('TalksFilter', () => {
       const filter = TalksFilter.fromUrlParams('hasNotes=true');
       expect(filter.filter([withNotes, withoutNotes])).toEqual([withNotes]);
     });
+
+    it('should filter by format', () => {
+      const talk = { id: '12', title: 't', year: 2024, url: '', duration: 0, topics: [], speakers: [], description: '', core_topic: '', format: 'talk' };
+      const podcast = { id: '13', title: 'p', year: 2024, url: '', duration: 0, topics: [], speakers: [], description: '', core_topic: '', format: 'podcast' };
+      const filter = TalksFilter.fromUrlParams('format=podcast');
+      expect(filter.filter([talk, podcast])).toEqual([podcast]);
+      expect(filter.toParams()).toContain('format=podcast');
+    });
   });
 
   describe('year filter types', () => {
@@ -185,7 +193,7 @@ describe('TalksFilter', () => {
 
   describe('fromUrlParams (full filter set)', () => {
     it('should parse all filter parameters from URL', () => {
-      const params = 'year=2023&author=Alice&topics=react,typescript&conference=ReactConf&hasNotes=true&rating=5&query=testing';
+      const params = 'year=2023&author=Alice&topics=react,typescript&conference=ReactConf&hasNotes=true&rating=5&query=testing&format=podcast';
       const filter = TalksFilter.fromUrlParams(params);
       expect(filter.year).toBe(2023);
       expect(filter.author).toBe('Alice');
@@ -194,9 +202,11 @@ describe('TalksFilter', () => {
       expect(filter.hasNotes).toBe(true);
       expect(filter.rating).toBe(5);
       expect(filter.query).toBe('testing');
+      expect(filter.formats).toEqual(['podcast']);
       const serialized = filter.toParams();
       expect(serialized).toContain('conference=ReactConf');
       expect(serialized).toContain('rating=5');
+      expect(serialized).toContain('format=podcast');
     });
   });
 });

--- a/src/utils/TalksFilter.ts
+++ b/src/utils/TalksFilter.ts
@@ -10,6 +10,7 @@ export class TalksFilter {
   readonly hasNotes: boolean;
   readonly rating: number | null;
   readonly query: string;
+  readonly formats: string[];
 
   constructor({
     year = null,
@@ -20,6 +21,7 @@ export class TalksFilter {
     hasNotes = false,
     rating = null,
     query = '',
+    formats = [],
   }: {
     year?: number | null;
     yearType?: 'specific' | 'before' | 'after' | 'last2' | 'last5' | null;
@@ -29,6 +31,7 @@ export class TalksFilter {
     hasNotes?: boolean;
     rating?: number | null;
     query?: string;
+    formats?: string[];
   }) {
     this.year = year;
     this.yearType = yearType;
@@ -38,6 +41,7 @@ export class TalksFilter {
     this.hasNotes = hasNotes;
     this.rating = rating;
     this.query = query || '';
+    this.formats = formats;
   }
 
   toParams(): string {
@@ -71,6 +75,9 @@ export class TalksFilter {
     }
     if (this.query) {
       params.set('query', this.query);
+    }
+    if (this.formats.length > 0) {
+      params.set('format', this.formats.join(','));
     }
     return params.toString();
   }
@@ -106,7 +113,8 @@ export class TalksFilter {
       const topicsMatch = this.topics.length === 0 || this.topics.every(t => talk.topics.includes(t));
       const conferenceMatch = !this.conference || talk.conference_name === this.conference;
       const notesMatch = !this.hasNotes || hasMeaningfulNotes(talk.notes);
-      return yearMatch && queryMatch && authorMatch && topicsMatch && conferenceMatch && notesMatch;
+      const formatMatch = this.formats.length === 0 || this.formats.includes((talk.format ?? 'talk'));
+      return yearMatch && queryMatch && authorMatch && topicsMatch && conferenceMatch && notesMatch && formatMatch;
     });
   }
 
@@ -120,6 +128,7 @@ export class TalksFilter {
     const conference = searchParams.get('conference');
     const hasNotesParam = searchParams.get('hasNotes');
     const ratingParam = searchParams.get('rating');
+    const formatParam = searchParams.get('format');
     const query = searchParams.get('query') || '';
     return new TalksFilter({
       yearType,
@@ -130,6 +139,7 @@ export class TalksFilter {
       hasNotes: hasNotesParam === 'true',
       rating: ratingParam ? parseInt(ratingParam, 10) : null,
       query,
+      formats: formatParam ? formatParam.split(',').filter(Boolean) : [],
     });
   }
 }

--- a/src/utils/talks.test.ts
+++ b/src/utils/talks.test.ts
@@ -150,4 +150,14 @@ describe('processTalks', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('1');
   });
+
+  it('maps resource_type to format field', () => {
+    const customItems = [
+      { ...items[0], resource_type: 'talk' },
+      { ...items[1], airtable_id: '10', resource_type: 'podcast' }
+    ];
+    const result = processTalks(customItems as any, false);
+    expect(result[0]).toHaveProperty('format', 'talk');
+    expect(result[1]).toHaveProperty('format', 'podcast');
+  });
 });

--- a/src/utils/talks.ts
+++ b/src/utils/talks.ts
@@ -14,6 +14,10 @@ export function hasMeaningfulNotes(notes: string | undefined | null): boolean {
 }
 
 export function transformAirtableItemToTalk(item: AirtableItem): Talk {
+  const type = item.resource_type?.toLowerCase();
+  let format: 'talk' | 'podcast' | 'article' = 'talk';
+  if (type === 'podcast' || type === 'videopodcast') format = 'podcast';
+  else if (type === 'article/paper') format = 'article';
   return {
     id: item.airtable_id,
     title: item.name,
@@ -25,7 +29,8 @@ export function transformAirtableItemToTalk(item: AirtableItem): Talk {
     core_topic: item.core_topic || '',
     notes: hasMeaningfulNotes(item.notes) ? item.notes : undefined,
     year: item.year,
-    conference_name: item.conference_name
+    conference_name: item.conference_name,
+    format
   };
 }
 


### PR DESCRIPTION
## Summary
- extend Talk type with `format`
- map Airtable `resource_type` to format and test it
- support `format` param in TalksFilter and related tests
- show format icons on TalkCard
- add FormatFilter component and integrate into TalksList
- cover new behavior with tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_6886a1ccca448323903e7c3065c9587d