### PR TITLE
Add Any format filter option

### DIFF
--- a/src/components/TalksList/FormatFilter.test.tsx
+++ b/src/components/TalksList/FormatFilter.test.tsx
@@ -10,6 +10,7 @@ describe('FormatFilter', () => {
     );
     expect(screen.getByLabelText(/talks/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/podcasts/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/any format/i)).toBeInTheDocument();
   });
 
   it('toggles formats and calls onChange', () => {
@@ -20,5 +21,15 @@ describe('FormatFilter', () => {
     const podcasts = screen.getByLabelText(/podcasts/i);
     fireEvent.click(podcasts);
     expect(onChange).toHaveBeenCalledWith(['talk', 'podcast']);
+  });
+
+  it('clears all formats when selecting Any', () => {
+    const onChange = vi.fn();
+    renderWithRouter(
+      <FormatFilter selectedFormats={['talk']} onChange={onChange} />
+    );
+    const any = screen.getByLabelText(/any format/i);
+    fireEvent.click(any);
+    expect(onChange).toHaveBeenCalledWith([]);
   });
 });

--- a/src/components/TalksList/FormatFilter.tsx
+++ b/src/components/TalksList/FormatFilter.tsx
@@ -13,8 +13,19 @@ export function FormatFilter({ selectedFormats, onChange }: FormatFilterProps) {
     onChange(newFormats);
   };
 
+  const clear = () => onChange([]);
+
   return (
     <div className="flex items-center gap-4">
+      <label className="inline-flex items-center gap-1 text-sm">
+        <input
+          type="checkbox"
+          checked={selectedFormats.length === 0}
+          onChange={clear}
+          aria-label="Any format"
+        />
+        Any
+      </label>
       <label className="inline-flex items-center gap-1 text-sm">
         <input
           type="checkbox"

--- a/src/utils/TalksFilter.test.ts
+++ b/src/utils/TalksFilter.test.ts
@@ -141,6 +141,11 @@ describe('TalksFilter', () => {
       expect(filter.filter([talk, podcast])).toEqual([podcast]);
       expect(filter.toParams()).toContain('format=podcast');
     });
+
+    it('should treat format=all as no format filter', () => {
+      const filter = TalksFilter.fromUrlParams('format=all');
+      expect(filter.formats).toEqual([]);
+    });
   });
 
   describe('year filter types', () => {

--- a/src/utils/TalksFilter.ts
+++ b/src/utils/TalksFilter.ts
@@ -139,7 +139,10 @@ export class TalksFilter {
       hasNotes: hasNotesParam === 'true',
       rating: ratingParam ? parseInt(ratingParam, 10) : null,
       query,
-      formats: formatParam ? formatParam.split(',').filter(Boolean) : [],
+      formats:
+        formatParam && formatParam !== 'all'
+          ? formatParam.split(',').filter(Boolean)
+          : [],
     });
   }
 }


### PR DESCRIPTION
## Summary
- support `format=all` query param
- update TalksFilter to interpret `format=all`
- add "Any" format checkbox for quick reset
- test the new filter behavior

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_6887f73ed4c0832389c276a23d3c6018