### PR TITLE
Improve collapse indication for sections

### DIFF
--- a/src/components/TalksList/TalkSection.test.tsx
+++ b/src/components/TalksList/TalkSection.test.tsx
@@ -37,6 +37,7 @@ describe('TalkSection', () => {
     );
     const button = screen.getByRole('button', { name: /Testing/ });
     expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveTextContent(/\[expanded\]/i);
     const cards = screen.getAllByTestId(/talk-/);
     expect(cards.length).toBeGreaterThanOrEqual(2);
   });
@@ -58,8 +59,10 @@ describe('TalkSection', () => {
     const toggle = screen.getByRole('button', { name: /Core/ });
     const details = screen.getByTestId('talk-section');
     expect(details).not.toHaveAttribute('open');
+    expect(toggle).toHaveTextContent(/\[collapsed\]/i);
     fireEvent.click(toggle);
     expect(details).toHaveAttribute('open');
+    expect(toggle).toHaveTextContent(/\[expanded\]/i);
     fireEvent.click(screen.getByText('author'));
     fireEvent.click(screen.getByText('topic'));
     fireEvent.click(screen.getByText('conf'));

--- a/src/components/TalksList/TalkSection.tsx
+++ b/src/components/TalksList/TalkSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/solid';
 import { Talk } from '../../types/talks';
 import { TalkCard } from './TalkCard';
 
@@ -38,9 +39,19 @@ export function TalkSection({
         role="button"
         onClick={handleToggle}
         aria-expanded={isOpen}
-        className="list-none cursor-pointer text-2xl font-bold text-gray-900 mb-6"
+        className="list-none cursor-pointer text-2xl font-bold text-gray-900 mb-6 flex items-center gap-2"
       >
-        {coreTopic} <span className="text-gray-500">({talks.length})</span>
+        {isOpen ? (
+          <ChevronDownIcon className="h-5 w-5" aria-hidden="true" />
+        ) : (
+          <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
+        )}
+        <span>
+          {coreTopic} <span className="text-gray-500">({talks.length})</span>
+          <span className="ml-2 text-sm text-gray-600">[
+            {isOpen ? 'expanded' : 'collapsed'}
+          ]</span>
+        </span>
       </summary>
       <div className="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {talks.map((talk) => (


### PR DESCRIPTION
## Summary
- show expand/collapse state in `TalkSection`
- check state text in `TalkSection` tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_688bee87d9c083239ff5daacc79afe1e