### PR TITLE
Add mergeParams helper for URL param merging

### DIFF
--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -4,6 +4,7 @@ import type { Talk } from '../../types/talks';
 import { Autocomplete } from '../../utils/Autocomplete';
 import { parseSearch } from '../../utils/SearchParser';
 import { TalksFilter } from '../../utils/TalksFilter';
+import { mergeParams } from '../../utils/url';
 
 interface SearchBoxProps {
   talks: Talk[];
@@ -63,12 +64,7 @@ export function SearchBox({ talks }: SearchBoxProps) {
       query: parsed.query,
     });
 
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, val] of searchParams.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, val);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
     setSuggestions([]);
   };

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -8,6 +8,7 @@ import { useScrollPosition } from '../../hooks/useScrollPosition';
 import { hasMeaningfulNotes } from '../../utils/talks';
 import { DocumentTextIcon, StarIcon } from '@heroicons/react/24/outline';
 import { TalksFilter } from '../../utils/TalksFilter';
+import { mergeParams } from '../../utils/url';
 import { SearchBox } from '../SearchBox';
 import { TopicsFilter } from './TopicsFilter';
 import { FormatFilter } from './FormatFilter';
@@ -48,14 +49,7 @@ export function TalksList() {
       ...filter,
       hasNotes: newValue,
     });
-    // Preserve extra params
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, value);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
   };
 
@@ -65,14 +59,7 @@ export function TalksList() {
       ...filter,
       rating: newValue,
     });
-    // Preserve extra params
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, value);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
   };
 
@@ -81,13 +68,7 @@ export function TalksList() {
       ...filter,
       topics
     });
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, value);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
   };
 
@@ -96,13 +77,7 @@ export function TalksList() {
       ...filter,
       formats,
     });
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query','format'].includes(key)) {
-        next.set(key, value);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
   };
 
@@ -127,14 +102,7 @@ export function TalksList() {
       ...filter,
       conference: newConference,
     });
-    // Preserve extra params
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, value);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
   };
 
@@ -170,14 +138,7 @@ export function TalksList() {
       rating: filter.rating,
       query: filter.query,
     });
-    // Preserve extra params
-    const current = new URLSearchParams(searchParams);
-    const next = new URLSearchParams(nextFilter.toParams());
-    for (const [key, value] of current.entries()) {
-      if (!next.has(key) && !['year','author','topics','conference','hasNotes','rating','query'].includes(key)) {
-        next.set(key, value);
-      }
-    }
+    const next = mergeParams(searchParams, new URLSearchParams(nextFilter.toParams()));
     setSearchParams(next);
   };
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { mergeParams, TALKS_FILTER_KEYS } from './url';
+
+describe('mergeParams', () => {
+  it('copies non-filter params', () => {
+    const current = new URLSearchParams('foo=bar&author=Alice');
+    const next = new URLSearchParams('author=Bob');
+    const result = mergeParams(current, next);
+    expect(result.get('foo')).toBe('bar');
+    expect(result.get('author')).toBe('Bob');
+  });
+
+  it('does not copy filter params', () => {
+    const current = new URLSearchParams('year=2023&extra=1');
+    const next = new URLSearchParams();
+    const result = mergeParams(current, next);
+    expect(result.get('extra')).toBe('1');
+    expect(result.get('year')).toBeNull();
+  });
+
+  it('does not override existing params in next', () => {
+    const current = new URLSearchParams('foo=bar');
+    const next = new URLSearchParams('foo=baz');
+    const result = mergeParams(current, next);
+    expect(result.get('foo')).toBe('baz');
+  });
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,22 @@
+export const TALKS_FILTER_KEYS = [
+  'year',
+  'author',
+  'topics',
+  'conference',
+  'hasNotes',
+  'rating',
+  'query',
+  'format'
+];
+
+export function mergeParams(
+  current: URLSearchParams,
+  next: URLSearchParams
+): URLSearchParams {
+  for (const [key, value] of current.entries()) {
+    if (!next.has(key) && !TALKS_FILTER_KEYS.includes(key)) {
+      next.set(key, value);
+    }
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary
- add `mergeParams` utility with filter keys
- replace manual loops in `SearchBox` and `TalksList`
- add unit tests for `mergeParams`

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688c81fdd7b4832896fe366ecc140996