### PR TITLE
Add navigation test for TalkDetail

### DIFF
--- a/src/components/TalkDetail/TalkDetail.test.tsx
+++ b/src/components/TalkDetail/TalkDetail.test.tsx
@@ -203,4 +203,24 @@ describe('TalkDetail', () => {
       expect(screen.getByText('Some actual notes')).toBeInTheDocument();
     });
   });
-}); 
+
+  describe('Navigation', () => {
+    it('preserves filters when going back to talks', () => {
+      setMockSearchParams(new URLSearchParams('author=Test%20Speaker&year=2023'));
+
+      (useTalks as any).mockImplementation(() => ({
+        talks: [mockTalk],
+        loading: false,
+        error: null
+      }));
+
+      (useParams as any).mockImplementation(() => ({ id: '1' }));
+      (useSearchParams as any).mockImplementation(() => [getMockSearchParams(), mockSetSearchParams]);
+
+      renderComponent();
+
+      const backLink = screen.getByRole('link', { name: /back to talks/i });
+      expect(backLink).toHaveAttribute('href', `/?${getMockSearchParams().toString()}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test that returning from a talk detail page keeps query params

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688c8201b15c83288fb3b2380c15b927