### PR TITLE
refactor: centralize classNames helper

### DIFF
--- a/src/components/TalksList/FormatFilter.tsx
+++ b/src/components/TalksList/FormatFilter.tsx
@@ -2,14 +2,11 @@ import { Fragment } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { VideoCameraIcon, MicrophoneIcon } from '@heroicons/react/24/outline';
+import { classNames } from '../../utils/classNames';
 
 interface FormatFilterProps {
   selectedFormats: string[];
   onChange: (formats: string[]) => void;
-}
-
-function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ');
 }
 
 export function FormatFilter({ selectedFormats, onChange }: FormatFilterProps) {

--- a/src/components/TalksList/TopicsFilter.tsx
+++ b/src/components/TalksList/TopicsFilter.tsx
@@ -2,15 +2,12 @@ import { Fragment, useMemo } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Talk } from '../../types/talks';
+import { classNames } from '../../utils/classNames';
 
 interface TopicsFilterProps {
   talks: Talk[];
   selectedTopics: string[];
   onChange: (topics: string[]) => void;
-}
-
-function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ');
 }
 
 export function TopicsFilter({ talks, selectedTopics, onChange }: TopicsFilterProps) {

--- a/src/components/TalksList/YearFilter.tsx
+++ b/src/components/TalksList/YearFilter.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react'
 import { Menu, Transition } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import { Talk } from '../../types/talks'
+import { classNames } from '../../utils/classNames'
 
 export type YearFilterType = 'specific' | 'before' | 'after' | 'last2' | 'last5';
 
@@ -14,10 +15,6 @@ interface YearFilterProps {
   talks: Talk[];
   selectedFilter: YearFilterData | null;
   onFilterChange: (filter: YearFilterData | null) => void;
-}
-
-function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ')
 }
 
 export function YearFilter({ talks, selectedFilter, onFilterChange }: YearFilterProps) {

--- a/src/utils/classNames.test.ts
+++ b/src/utils/classNames.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { classNames } from './classNames';
+
+describe('classNames', () => {
+  it('joins class names with spaces and ignores falsy values', () => {
+    expect(classNames('foo', undefined, '', 'bar', false, 'baz')).toBe('foo bar baz');
+  });
+});

--- a/src/utils/classNames.ts
+++ b/src/utils/classNames.ts
@@ -1,0 +1,7 @@
+/**
+ * Utility to join CSS class names conditionally.
+ * Filters out falsy values and joins the rest with spaces.
+ */
+export function classNames(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add shared `classNames` utility
- remove duplicate helpers in filter components
- cover `classNames` with unit tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688dbd0586788328a1a345a82ef621f7