### PR TITLE
refactor: centralize whitespace skipping and tidy timeout types

### DIFF
--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -7,6 +7,20 @@ const INITIAL_DELAY = 100;
 const MAX_ATTEMPTS = 10;
 const MAX_DELAY = 2000;
 
+function isValidScrollPosition(value: string | null): boolean {
+  if (!value) return false;
+
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  const parsed = Number(trimmed);
+  if (isNaN(parsed)) return false;
+  if (!isFinite(parsed)) return false;
+  if (!Number.isInteger(parsed) || parsed < 0) return false;
+
+  return true;
+}
+
 /**
  * Hook to save and restore scroll position.
  *
@@ -15,8 +29,8 @@ const MAX_DELAY = 2000;
  */
 export const useScrollPosition = () => {
   const location = useLocation();
-  const timeoutRef = useRef<NodeJS.Timeout>();
-  const retryTimeoutRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const attemptRef = useRef(0);
   const isIndexPage = location.pathname === '/' || location.pathname === '';
 
@@ -26,28 +40,6 @@ export const useScrollPosition = () => {
     const scrollPosition = window.scrollY;
     sessionStorage.setItem(SCROLL_INDEX_KEY, scrollPosition.toString());
   }, [isIndexPage]);
-
-  const isValidScrollPosition = (value: string | null): boolean => {
-    if (!value) return false;
-    
-    // Trim whitespace
-    const trimmed = value.trim();
-    if (!trimmed) return false;
-    
-    // Parse as number
-    const parsed = Number(trimmed);
-    
-    // Check if it's a valid number
-    if (isNaN(parsed)) return false;
-    
-    // Check if it's finite
-    if (!isFinite(parsed)) return false;
-    
-    // Check if it's a non-negative integer
-    if (!Number.isInteger(parsed) || parsed < 0) return false;
-    
-    return true;
-  };
 
   const restoreScrollPosition = useCallback(() => {
     if (!isIndexPage) return;

--- a/src/utils/SearchParser.ts
+++ b/src/utils/SearchParser.ts
@@ -12,13 +12,11 @@ export function parseSearch(input: string): ParsedSearch {
   // Process the input character by character to handle quoted strings
   let i = 0;
   const text = input.trim();
-  
+
   while (i < text.length) {
     // Skip whitespace
-    while (i < text.length && /\s/.test(text[i])) {
-      i++;
-    }
-    
+    i = skipWhitespace(text, i);
+
     if (i >= text.length) break;
     
     // Check for author: or topic: prefix
@@ -44,13 +42,8 @@ export function parseSearch(input: string): ParsedSearch {
 }
 
 function extractValue(text: string, startIndex: number): { text: string; nextIndex: number } {
-  let i = startIndex;
-  
-  // Skip whitespace
-  while (i < text.length && /\s/.test(text[i])) {
-    i++;
-  }
-  
+  let i = skipWhitespace(text, startIndex);
+
   if (i >= text.length) {
     return { text: '', nextIndex: i };
   }
@@ -78,12 +71,10 @@ function extractValue(text: string, startIndex: number): { text: string; nextInd
   // Only continue if we have a common name pattern (no keywords in between)
   let potentialMultiWord = value;
   let tempIndex = i;
-  
+
   while (tempIndex < text.length) {
     // Skip whitespace
-    while (tempIndex < text.length && /\s/.test(text[tempIndex])) {
-      tempIndex++;
-    }
+    tempIndex = skipWhitespace(text, tempIndex);
     
     if (tempIndex >= text.length || isAtKeyword(text, tempIndex)) {
       break;
@@ -134,4 +125,11 @@ function extractQueryWord(text: string, startIndex: number): { text: string; nex
 function isAtKeyword(text: string, index: number): boolean {
   const remaining = text.slice(index).toLowerCase();
   return remaining.startsWith('author:') || remaining.startsWith('topic:');
+}
+
+function skipWhitespace(text: string, index: number): number {
+  while (index < text.length && /\s/.test(text[index])) {
+    index++;
+  }
+  return index;
 }


### PR DESCRIPTION
## Summary
- refactor search parsing to use a shared whitespace skipper
- pull scroll position validation out of the hook and type timeouts generically

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f2c17ce7883288a6c87ee0372bd6f