### PR TITLE
Refactor test utilities to improve type safety

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { TalksList } from './components/TalksList'
 import { TalkDetail } from './components/TalkDetail'
 import { Footer } from './components/Footer'
 import { BackToTopButton } from './components/BackToTopButton'
-import { LoadingSpinner, Button } from './components/ui'
+import { LoadingSpinner } from './components/ui'
 
 function Header() {
   return (

--- a/src/components/TalksList/TalkCard.tsx
+++ b/src/components/TalksList/TalkCard.tsx
@@ -4,7 +4,6 @@ import { Talk } from '../../types/talks';
 import { formatDuration } from '../../utils/format';
 import { hasMeaningfulNotes } from '../../utils/talks';
 import { DocumentTextIcon, PlayIcon, VideoCameraIcon, MicrophoneIcon } from '@heroicons/react/24/outline';
-import { Button } from '../ui';
 
 interface TalkCardProps {
   talk: Talk;

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -141,8 +141,7 @@ describe('Button', () => {
       );
       
       const icon = screen.getByTestId('icon');
-      const button = screen.getByRole('button');
-      
+
       expect(icon).toBeInTheDocument();
       expect(icon).toHaveClass('h-5', 'w-5', 'mr-2');
     });

--- a/src/hooks/useScrollPosition.test.tsx
+++ b/src/hooks/useScrollPosition.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { useScrollPosition } from './useScrollPosition';
 import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { setMockSearchParams } from '../test/utils';
 
 const SCROLL_INDEX_KEY = 'scroll_index';

--- a/src/test/consolidated/testUtilities.test.ts
+++ b/src/test/consolidated/testUtilities.test.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createElement } from 'react';
-import { 
+import {
   MockDataFactory,
   TestSetupHelper,
   MockComponentGenerator,
   RenderHelper
 } from './testUtilities';
-import type { Talk } from '../../types/talks';
 
 // Mock the useTalks hook before importing utilities
 vi.mock('../../hooks/useTalks', () => ({
@@ -111,7 +110,6 @@ describe('Consolidated Test Utilities', () => {
 
     it('sets up component-specific test environment', () => {
       const cleanup = TestSetupHelper.setupComponentTest('TalksList', {
-        mockChildComponents: true,
         setupHandlers: true
       });
       
@@ -171,9 +169,7 @@ describe('Consolidated Test Utilities', () => {
   describe('Integration', () => {
     it('works together to setup and render test scenarios', () => {
       // Setup test environment
-      const testCleanup = TestSetupHelper.setupComponentTest('TalksList', {
-        mockChildComponents: true
-      });
+      const testCleanup = TestSetupHelper.setupComponentTest('TalksList');
       
       // Create test data
       const talks = MockDataFactory.createTalksForFiltering();

--- a/src/test/consolidated/testUtilities.tsx
+++ b/src/test/consolidated/testUtilities.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { render, RenderResult } from '@testing-library/react';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { vi, type Mock } from 'vitest';
 import type { Talk } from '../../types/talks';
 import { useTalks } from '../../hooks/useTalks';
@@ -141,7 +141,6 @@ export type RouterTestOptions = {
 };
 
 export type ComponentTestOptions = {
-  mockChildComponents?: boolean;
   setupHandlers?: boolean;
   customMocks?: Record<string, Mock>;
 };
@@ -208,10 +207,10 @@ export class TestSetupHelper {
   }
 
   static setupComponentTest(
-    componentName: string, 
+    componentName: string,
     options: ComponentTestOptions = {}
   ): () => void {
-    const { mockChildComponents = false, setupHandlers = false, customMocks = {} } = options;
+    const { setupHandlers = false, customMocks = {} } = options;
     
     const cleanupFunctions: (() => void)[] = [];
 
@@ -260,9 +259,20 @@ export type MockComponentOptions = {
 export class MockComponentGenerator {
   static createMockTalkCard(options: MockComponentOptions = {}) {
     const { includeHandlers = true, includeTestIds = true } = options;
-    
-    function MockTalkCard(props: any) {
-      const { talk, onAuthorClick, onTopicClick, onConferenceClick } = props;
+
+    interface MockTalkCardProps {
+      talk: Talk;
+      onAuthorClick?: (author: string) => void;
+      onTopicClick?: (topic: string) => void;
+      onConferenceClick?: (conference?: string) => void;
+    }
+
+    function MockTalkCard({
+      talk,
+      onAuthorClick,
+      onTopicClick,
+      onConferenceClick
+    }: MockTalkCardProps) {
       
       return (
         <div data-testid={includeTestIds ? `talk-${talk.id}` : undefined}>
@@ -289,9 +299,13 @@ export class MockComponentGenerator {
 
   static createMockTalkSection(options: MockComponentOptions = {}) {
     const { includeTestIds = true } = options;
-    
-    function MockTalkSection(props: any) {
-      const { coreTopic, talks } = props;
+
+    interface MockTalkSectionProps {
+      coreTopic: string;
+      talks: Talk[];
+    }
+
+    function MockTalkSection({ coreTopic, talks }: MockTalkSectionProps) {
       
       return (
         <section data-testid={includeTestIds ? 'talk-section' : undefined}>
@@ -310,9 +324,12 @@ export class MockComponentGenerator {
 
   static createMockTalksList(options: MockComponentOptions = {}) {
     const { includeTestIds = true } = options;
-    
-    function MockTalksList(props: any) {
-      const { talks = [] } = props;
+
+    interface MockTalksListProps {
+      talks?: Talk[];
+    }
+
+    function MockTalksList({ talks = [] }: MockTalksListProps) {
       
       return (
         <div data-testid={includeTestIds ? 'talks-list' : undefined}>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,9 +3,10 @@ import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import type { Talk } from '../types/talks';
 
 // Cache parsed JSON to avoid repeated I/O
-let cachedTalksData: any = null;
+let cachedTalksData: Talk[] | null = null;
 
 // Automatically cleanup after each test
 afterEach(() => {
@@ -21,11 +22,11 @@ global.fetch = vi.fn(async (url: string | URL | Request) => {
     if (!cachedTalksData) {
       const filePath = join(process.cwd(), 'public', 'data', 'talks.json');
       const data = readFileSync(filePath, 'utf-8');
-      cachedTalksData = JSON.parse(data);
+      cachedTalksData = JSON.parse(data) as Talk[];
     }
     return {
       ok: true,
-      json: async () => cachedTalksData
+      json: async () => cachedTalksData as Talk[]
     } as Response;
   }
   throw new Error(`Unhandled fetch request: ${urlStr}`);

--- a/src/test/utils.test.tsx
+++ b/src/test/utils.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { validateComponentProps } from './utils';
+
+const HelloComponent = ({ message }: { message: string }) => <div>{message}</div>;
+
+describe('validateComponentProps', () => {
+  it('returns success for valid props', () => {
+    const result = validateComponentProps(HelloComponent, { message: 'Hi' });
+    expect(result.success).toBe(true);
+    expect(result.element.props.message).toBe('Hi');
+  });
+});

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -141,9 +141,9 @@ export const renderWithoutRouter = (ui: React.ReactElement) => {
 };
 
 // Fast shallow test helper for component prop validation
-export const validateComponentProps = (
-  Component: React.ComponentType<any>,
-  props: any
+export const validateComponentProps = <P extends object>(
+  Component: React.ComponentType<P>,
+  props: P
 ) => {
   // Just verify the component can be instantiated with props
   // without full DOM rendering - much faster for prop validation
@@ -153,4 +153,4 @@ export const validateComponentProps = (
   } catch (error) {
     return { success: false, error };
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- make validateComponentProps generic for stronger type safety
- cache test data as `Talk[]` and type mock component props
- add tests for component prop validation

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689090b0d12083288cc2b008065f3a8d