### PR TITLE
Add MIT license and sanitize markdown notes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Eduardo Ferro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,8 +1,8 @@
 # Plan
 
 ## Quality and maintainability improvements
-- [ ] Add missing MIT `LICENSE` file referenced in the README.
-- [ ] Configure `ReactMarkdown` with `rehype-sanitize` to prevent potential XSS in `TalkDetail`.
+- [x] Add missing MIT `LICENSE` file referenced in the README.
+- [x] Configure `ReactMarkdown` with `rehype-sanitize` to prevent potential XSS in `TalkDetail`.
 - [ ] Set up Husky pre-commit hook to run `npm test -- --run` and `npm run lint`.
 - [ ] Add a `typecheck` script (`tsc --noEmit`) and integrate it into CI.
 - [ ] Resolve `Unknown env config "http-proxy"` npm warning by cleaning up `.npmrc` or environment configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.7.0"
+        "react-router-dom": "^7.7.0",
+        "rehype-sanitize": "^6.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -3671,6 +3672,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -5652,6 +5668,20 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.7.0"
+    "react-router-dom": "^7.7.0",
+    "rehype-sanitize": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/components/TalkDetail/TalkDetail.test.tsx
+++ b/src/components/TalkDetail/TalkDetail.test.tsx
@@ -202,6 +202,20 @@ describe('TalkDetail', () => {
       expect(screen.getByText('Key Notes')).toBeInTheDocument();
       expect(screen.getByText('Some actual notes')).toBeInTheDocument();
     });
+
+    it('sanitizes HTML in notes to prevent XSS', () => {
+      const maliciousNotes = '<img src=x onerror="alert(1)" /><script>alert("xss")</script>'; 
+      (useTalks as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        talks: [createTalk({ notes: maliciousNotes })],
+        loading: false,
+        error: null
+      }));
+
+      const { container } = renderComponent();
+
+      expect(container.querySelector('script')).toBeNull();
+      expect(container.querySelector('img')).toBeNull();
+    });
   });
 
   describe('Navigation', () => {

--- a/src/components/TalkDetail/index.tsx
+++ b/src/components/TalkDetail/index.tsx
@@ -7,6 +7,7 @@ import { LoadingSpinner, ErrorMessage, PageContainer, Button } from '../ui';
 import { Talk } from '../../types/talks';
 import { formatDuration } from '../../utils/format';
 import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
 import { hasMeaningfulNotes } from '../../utils/talks';
 
 
@@ -124,7 +125,9 @@ function TalkDetail() {
             <div className="mt-8">
               <h2 className="text-xl font-semibold text-gray-900 mb-4">Key Notes</h2>
               <div className="prose prose-blue max-w-none">
-                <ReactMarkdown>{talk.notes}</ReactMarkdown>
+                <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+                  {talk.notes}
+                </ReactMarkdown>
               </div>
             </div>
           )}
@@ -161,4 +164,4 @@ function TalkDetail() {
     </PageContainer>
   );
 }
-export { TalkDetail }; 
+export { TalkDetail };


### PR DESCRIPTION
## Summary
- add missing MIT license file referenced in README
- sanitize TalkDetail markdown notes using rehype-sanitize to prevent XSS
- document completed tasks in plan

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aeaf3f1a0c832896f675b3244e02a3