### PR TITLE
chore: add pre-commit hooks and typecheck

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run tests
         run: npm test -- --run
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -62,10 +62,13 @@ jobs:
           
       - name: Install Dependencies
         run: npm ci
-        
+
       - name: Run tests
         run: npm test -- --run
-        
+
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build site
         run: npm run build
         

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+npm test -- --run
+npm run lint

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3,7 +3,7 @@
 ## Quality and maintainability improvements
 - [x] Add missing MIT `LICENSE` file referenced in the README.
 - [x] Configure `ReactMarkdown` with `rehype-sanitize` to prevent potential XSS in `TalkDetail`.
-- [ ] Set up Husky pre-commit hook to run `npm test -- --run` and `npm run lint`.
-- [ ] Add a `typecheck` script (`tsc --noEmit`) and integrate it into CI.
+- [x] Set up Husky pre-commit hook to run `npm test -- --run` and `npm run lint`.
+- [x] Add a `typecheck` script (`tsc --noEmit`) and integrate it into CI.
 - [ ] Resolve `Unknown env config "http-proxy"` npm warning by cleaning up `.npmrc` or environment configuration.
 - [ ] Include an `npm audit` step in CI to detect vulnerabilities and keep dependencies updated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-plugin-react-refresh": "^0.4.5",
         "globals": "^16.3.0",
         "happy-dom": "^18.0.1",
+        "husky": "^9.1.7",
         "jsdom": "^26.0.0",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
@@ -3777,6 +3778,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:components": "vitest run src/components",
     "test:changed": "vitest run --changed",
     "test:single": "vitest run --singleThread",
-    "test:profile": "vitest run --reporter=verbose --slowTestThreshold=1000"
+    "test:profile": "vitest run --reporter=verbose --slowTestThreshold=1000",
+    "prepare": "husky",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@headlessui/react": "1.7.17",
@@ -47,6 +49,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "globals": "^16.3.0",
     "happy-dom": "^18.0.1",
+    "husky": "^9.1.7",
     "jsdom": "^26.0.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
## Summary
- run tests and lint before commits via Husky
- add typecheck script and run it in CI workflows
- check off completed items in the plan

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aecab792648328a82f1b1dc1731ca0