### PR TITLE
Fix keyword and uppercase query handling in SearchParser

### DIFF
--- a/src/utils/SearchParser.test.ts
+++ b/src/utils/SearchParser.test.ts
@@ -77,4 +77,18 @@ describe('parseSearch', () => {
     expect(result.topics).toEqual([]);
     expect(result.query).toBe('');
   });
+
+  it('does not treat the next keyword as part of a missing author value', () => {
+    const result = parseSearch('author: topic:architecture inspiring talk');
+    expect(result.author).toBeNull();
+    expect(result.topics).toEqual(['architecture']);
+    expect(result.query).toBe('inspiring talk');
+  });
+
+  it('keeps uppercase general query terms out of author values', () => {
+    const result = parseSearch('author:Kent Beck TDD fundamentals');
+    expect(result.author).toBe('Kent Beck');
+    expect(result.topics).toEqual([]);
+    expect(result.query).toBe('TDD fundamentals');
+  });
 });

--- a/src/utils/SearchParser.ts
+++ b/src/utils/SearchParser.ts
@@ -127,6 +127,9 @@ function readSimpleWord(text: string, startIndex: number): { text: string; nextI
   let i = startIndex;
   let word = '';
   while (i < text.length && !/\s/.test(text[i])) {
+    if (isAtKeyword(text, i)) {
+      break;
+    }
     word += text[i];
     i++;
   }
@@ -153,5 +156,17 @@ function collectContinuationWords(text: string, index: number, currentValue: str
 }
 
 function shouldContinueName(word: string): boolean {
-  return isCapitalized(word) || isCommonNameWord(word);
+  if (isCommonNameWord(word)) {
+    return true;
+  }
+
+  if (/^[A-Z]\.$/.test(word)) {
+    return true;
+  }
+
+  if (!isCapitalized(word)) {
+    return false;
+  }
+
+  return /[a-z]/.test(word.slice(1));
 }


### PR DESCRIPTION
## Summary
- add regression tests covering missing author values and uppercase general query terms
- ensure unquoted value parsing stops at keyword boundaries and avoids absorbing uppercase abbreviations into names

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c9e17f8c548328805b67293e6c8481