### PR TITLE
Add Quick Watch filter for talks under 15 minutes

### DIFF
--- a/src/components/TalksList/ActiveFilters.tsx
+++ b/src/components/TalksList/ActiveFilters.tsx
@@ -9,6 +9,7 @@ interface ActiveFiltersProps {
   onRemoveYearFilter: () => void;
   onRemoveHasNotes: () => void;
   onRemoveRating: () => void;
+  onRemoveQuickWatch: () => void;
   onRemoveFormat: (format: string) => void;
 }
 
@@ -19,6 +20,7 @@ export function ActiveFilters({
   onRemoveYearFilter,
   onRemoveHasNotes,
   onRemoveRating,
+  onRemoveQuickWatch,
   onRemoveFormat,
 }: ActiveFiltersProps) {
   // Check if any filters are active
@@ -26,6 +28,7 @@ export function ActiveFilters({
     filter.conference ||
     yearFilter ||
     filter.hasNotes ||
+    filter.quickWatch ||
     filter.rating === 5 ||
     filter.formats.length > 0;
 
@@ -75,6 +78,18 @@ export function ActiveFilters({
         </div>
       )}
       
+      {filter.quickWatch && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500">Filter:</span>
+          <FilterChip
+            onRemove={onRemoveQuickWatch}
+            ariaLabel="Remove Quick Watch filter"
+          >
+            Quick Watch
+          </FilterChip>
+        </div>
+      )}
+
       {filter.rating === 5 && (
         <div className="flex items-center gap-2">
           <span className="text-sm text-gray-500">Filter:</span>

--- a/src/components/TalksList/index.tsx
+++ b/src/components/TalksList/index.tsx
@@ -6,7 +6,7 @@ import { YearFilter, type YearFilterData } from './YearFilter';
 import { useUrlFilter } from '../../hooks/useUrlFilter';
 import { useScrollPosition } from '../../hooks/useScrollPosition';
 import { useFilterHandlers } from '../../hooks/useFilterHandlers';
-import { DocumentTextIcon, StarIcon } from '@heroicons/react/24/outline';
+import { DocumentTextIcon, StarIcon, BoltIcon } from '@heroicons/react/24/outline';
 import { LoadingSpinner, ErrorMessage, PageContainer, Button } from '../ui';
 
 import { SearchBox } from '../SearchBox';
@@ -31,6 +31,7 @@ export function TalksList() {
     handleConferenceClick,
     handleTopicClick,
     handleYearFilterChange,
+    handleQuickWatchClick,
   } = useFilterHandlers(filter, updateFilter);
 
   // Derive yearType and year from TalksFilter
@@ -91,6 +92,15 @@ export function TalksList() {
         <FormatFilter selectedFormats={filter.formats} onChange={handleFormatChange} />
         <Button
           variant="toggle"
+          active={filter.quickWatch}
+          onClick={handleQuickWatchClick}
+          aria-label="Toggle Quick Watch filter"
+          icon={<BoltIcon />}
+        >
+          Quick Watch
+        </Button>
+        <Button
+          variant="toggle"
           active={filter.hasNotes}
           onClick={handleHasNotesClick}
           aria-label="Toggle Has Notes filter"
@@ -117,6 +127,7 @@ export function TalksList() {
         onRemoveYearFilter={() => handleYearFilterChange(null)}
         onRemoveHasNotes={handleHasNotesClick}
         onRemoveRating={handleRatingClick}
+        onRemoveQuickWatch={handleQuickWatchClick}
         onRemoveFormat={(format) => handleFormatChange(filter.formats.filter(f => f !== format))}
       />
 

--- a/src/hooks/useFilterHandlers.ts
+++ b/src/hooks/useFilterHandlers.ts
@@ -34,6 +34,10 @@ export function useFilterHandlers(filter: TalksFilter, updateFilter: UpdateFilte
     updateFilter({ query: newQuery });
   }, [filter.query, updateFilter]);
 
+  const handleQuickWatchClick = useCallback(() => {
+    updateFilter({ quickWatch: !filter.quickWatch });
+  }, [filter.quickWatch, updateFilter]);
+
   const handleYearFilterChange = useCallback((yearFilter: YearFilterData | null) => {
     if (!yearFilter) {
       updateFilter({ yearType: null, year: null });
@@ -49,5 +53,6 @@ export function useFilterHandlers(filter: TalksFilter, updateFilter: UpdateFilte
     handleConferenceClick,
     handleTopicClick,
     handleYearFilterChange,
+    handleQuickWatchClick,
   };
 }

--- a/src/utils/TalksFilter.test.ts
+++ b/src/utils/TalksFilter.test.ts
@@ -1014,4 +1014,85 @@ describe('TalksFilter', () => {
       expect(result).toEqual([talkWithoutFormat]);
     });
   });
+
+  describe('Quick Watch (Under 15 Minutes) Filter', () => {
+    it('should include talks under 15 minutes when quickWatch is true', () => {
+      const shortTalk = createTalk({ id: '1', duration: 600 }); // 10 min
+      const longTalk = createTalk({ id: '2', duration: 3600 }); // 60 min
+
+      const filter = new TalksFilter({ quickWatch: true });
+      expect(filter.filter([shortTalk, longTalk])).toEqual([shortTalk]);
+    });
+
+    it('should include all talks when quickWatch is false', () => {
+      const shortTalk = createTalk({ id: '1', duration: 600 });
+      const longTalk = createTalk({ id: '2', duration: 3600 });
+
+      const filter = new TalksFilter({ quickWatch: false });
+      expect(filter.filter([shortTalk, longTalk])).toEqual([shortTalk, longTalk]);
+    });
+
+    it('should exclude talks exactly at 15 minutes (900 seconds)', () => {
+      const exactlyFifteen = createTalk({ id: '1', duration: 900 });
+
+      const filter = new TalksFilter({ quickWatch: true });
+      expect(filter.filter([exactlyFifteen])).toEqual([]);
+    });
+
+    it('should include talks just under 15 minutes', () => {
+      const justUnder = createTalk({ id: '1', duration: 899 });
+
+      const filter = new TalksFilter({ quickWatch: true });
+      expect(filter.filter([justUnder])).toEqual([justUnder]);
+    });
+
+    it('should include talks with zero duration when quickWatch is true', () => {
+      const zeroDuration = createTalk({ id: '1', duration: 0 });
+
+      const filter = new TalksFilter({ quickWatch: true });
+      expect(filter.filter([zeroDuration])).toEqual([zeroDuration]);
+    });
+
+    it('should default quickWatch to false', () => {
+      const filter = new TalksFilter({});
+      expect(filter.quickWatch).toBe(false);
+    });
+
+    it('should combine with other filters', () => {
+      const shortDDD = createTalk({ id: '1', duration: 600, year: 2023, conference_name: 'DDD Europe' });
+      const longDDD = createTalk({ id: '2', duration: 3600, year: 2023, conference_name: 'DDD Europe' });
+      const shortOther = createTalk({ id: '3', duration: 600, year: 2023, conference_name: 'Other' });
+
+      const filter = new TalksFilter({ quickWatch: true, conference: 'DDD Europe' });
+      expect(filter.filter([shortDDD, longDDD, shortOther])).toEqual([shortDDD]);
+    });
+
+    describe('URL parameter serialization', () => {
+      it('should serialize quickWatch=true to URL params', () => {
+        const filter = new TalksFilter({ quickWatch: true });
+        expect(filter.toParams()).toContain('quickWatch=true');
+      });
+
+      it('should not serialize quickWatch=false to URL params', () => {
+        const filter = new TalksFilter({ quickWatch: false });
+        expect(filter.toParams()).not.toContain('quickWatch');
+      });
+
+      it('should parse quickWatch from URL params', () => {
+        const filter = TalksFilter.fromUrlParams('quickWatch=true');
+        expect(filter.quickWatch).toBe(true);
+      });
+
+      it('should default quickWatch to false when not in URL', () => {
+        const filter = TalksFilter.fromUrlParams('');
+        expect(filter.quickWatch).toBe(false);
+      });
+
+      it('should round-trip quickWatch through URL params', () => {
+        const original = new TalksFilter({ quickWatch: true });
+        const restored = TalksFilter.fromUrlParams(original.toParams());
+        expect(restored.quickWatch).toBe(true);
+      });
+    });
+  });
 });

--- a/src/utils/TalksFilter.ts
+++ b/src/utils/TalksFilter.ts
@@ -40,6 +40,7 @@ export interface TalksFilterData {
   rating?: number | null;
   query?: string;
   formats?: string[];
+  quickWatch?: boolean;
   _testCurrentYear?: number; // For deterministic testing - injects "now"
 }
 
@@ -53,6 +54,7 @@ export class TalksFilter {
   readonly rating: number | null;
   readonly query: string;
   readonly formats: string[];
+  readonly quickWatch: boolean;
   private readonly _testCurrentYear?: number;
 
   constructor({
@@ -65,6 +67,7 @@ export class TalksFilter {
     rating = null,
     query = '',
     formats = [],
+    quickWatch = false,
     _testCurrentYear,
   }: TalksFilterData = {}) {
     this.year = year;
@@ -76,6 +79,7 @@ export class TalksFilter {
     this.rating = rating;
     this.query = query || '';
     this.formats = formats;
+    this.quickWatch = quickWatch;
     this._testCurrentYear = _testCurrentYear;
   }
 
@@ -128,6 +132,9 @@ export class TalksFilter {
     if (this.formats.length > 0) {
       params.set('format', this.formats.join(','));
     }
+    if (this.quickWatch) {
+      params.set('quickWatch', 'true');
+    }
     return params.toString();
   }
 
@@ -142,6 +149,7 @@ export class TalksFilter {
       const notesMatch = !this.hasNotes || hasMeaningfulNotes(talk.notes);
       const formatMatch =
         this.formats.length === 0 || this.formats.includes(talk.format ?? 'talk');
+      const quickWatchMatch = !this.quickWatch || talk.duration < 900;
       return (
         yearMatch &&
         queryMatch &&
@@ -149,7 +157,8 @@ export class TalksFilter {
         topicsMatch &&
         conferenceMatch &&
         notesMatch &&
-        formatMatch
+        formatMatch &&
+        quickWatchMatch
       );
     });
   }
@@ -163,6 +172,7 @@ export class TalksFilter {
     const hasNotesParam = searchParams.get('hasNotes');
     const ratingParam = searchParams.get('rating');
     const formatParam = searchParams.get('format');
+    const quickWatchParam = searchParams.get('quickWatch');
 
     // Migrate legacy author/topics params to unified query
     const queryTerms: string[] = [];
@@ -193,6 +203,7 @@ export class TalksFilter {
       topics: [],    // No longer used - migrated to query
       conference: conference || null,
       hasNotes: hasNotesParam === 'true',
+      quickWatch: quickWatchParam === 'true',
       rating: parseValidInt(ratingParam),
       query: queryTerms.length > 0 ? queryTerms.join(' ') : '',
       formats:

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -7,7 +7,8 @@ export const TALKS_FILTER_KEYS = [
   'hasNotes',
   'rating',
   'query',
-  'format'
+  'format',
+  'quickWatch'
 ] as const;
 
 export function mergeParams(


### PR DESCRIPTION
## Summary
This PR adds a new "Quick Watch" filter that allows users to view only talks under 15 minutes in duration. The filter can be toggled via a button in the UI and is persisted through URL parameters.

## Key Changes
- **TalksFilter.ts**: Added `quickWatch` boolean property to filter talks with duration < 900 seconds (15 minutes)
  - Implemented serialization/deserialization of `quickWatch` parameter in URL params
  - Integrated quick watch matching logic into the filter pipeline
- **TalksList/index.tsx**: Added Quick Watch toggle button with BoltIcon to the filter controls
  - Wired up handler to update filter state when button is clicked
- **TalksList/ActiveFilters.tsx**: Added visual display of active Quick Watch filter as a removable chip
- **useFilterHandlers.ts**: Created `handleQuickWatchClick` callback to toggle the quick watch filter
- **url.ts**: Added `quickWatch` to the list of recognized filter URL parameters
- **TalksFilter.test.ts**: Added comprehensive test suite covering:
  - Basic filtering behavior (includes talks under 15 min, excludes 15+ min)
  - Edge cases (exactly 15 minutes, zero duration, just under threshold)
  - Default behavior (defaults to false)
  - Combination with other filters
  - URL parameter serialization and round-tripping

## Implementation Details
- Quick Watch filter uses strict less-than comparison (`< 900` seconds), so talks exactly 15 minutes are excluded
- The filter defaults to `false` and only serializes to URL params when `true` (keeping URLs clean)
- The feature integrates seamlessly with existing filters and can be combined with conference, year, format, and other filters

https://claude.ai/code/session_016dzTqFZd2CZmFfm3Hevdi7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core filtering and URL serialization logic, so mistakes could change what users see or break shareable links; coverage is added, but it still affects a central code path.
> 
> **Overview**
> Adds a new **Quick Watch** filter that limits the talks list to items with `duration < 900` seconds, and persists the toggle via the `quickWatch=true` URL parameter.
> 
> Updates the Talks UI to include a Quick Watch toggle button and an active-filter chip with remove behavior, wires a new handler in `useFilterHandlers`, extends `TalksFilter` (data model, filtering, and URL (de)serialization), updates allowed URL keys, and adds targeted tests covering behavior, edge cases, and URL round-tripping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ec8f5cc680b89b184708834e3038840b8ec344a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->