### PR TITLE
Add blog URL support to talk details

### DIFF
--- a/src/components/TalkDetail/TalkDetail.test.tsx
+++ b/src/components/TalkDetail/TalkDetail.test.tsx
@@ -134,6 +134,45 @@ describe('TalkDetail', () => {
     });
   });
 
+  describe('Blog Link', () => {
+    it('renders blog link when blog_url is present', () => {
+      (useTalks as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        talks: [createTalk({ blog_url: 'https://www.eferro.net/2017/03/interesting-talkspodcasts-march.html' })],
+        loading: false,
+        error: null
+      }));
+      renderComponent();
+
+      const blogLink = screen.getByRole('link', { name: /mentioned in curator's blog/i });
+      expect(blogLink).toBeInTheDocument();
+      expect(blogLink).toHaveAttribute('href', 'https://www.eferro.net/2017/03/interesting-talkspodcasts-march.html');
+      expect(blogLink).toHaveAttribute('target', '_blank');
+      expect(blogLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('does not render blog link when blog_url is absent', () => {
+      (useTalks as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        talks: [createTalk({ blog_url: undefined })],
+        loading: false,
+        error: null
+      }));
+      renderComponent();
+
+      expect(screen.queryByRole('link', { name: /mentioned in curator's blog/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render blog link when blog_url is empty string', () => {
+      (useTalks as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        talks: [createTalk({ blog_url: '' })],
+        loading: false,
+        error: null
+      }));
+      renderComponent();
+
+      expect(screen.queryByRole('link', { name: /mentioned in curator's blog/i })).not.toBeInTheDocument();
+    });
+  });
+
   describe('Notes Section', () => {
     it('does not render notes section when notes are not present', () => {
       (useTalks as ReturnType<typeof vi.fn>).mockImplementation(() => ({

--- a/src/components/TalkDetail/index.tsx
+++ b/src/components/TalkDetail/index.tsx
@@ -128,6 +128,20 @@ function TalkDetail() {
             </p>
           </div>
 
+          {talk.blog_url && (
+            <div className="mb-6">
+              <a
+                href={talk.blog_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium"
+              >
+                <span className="mr-2" aria-hidden="true">📝</span>
+                Mentioned in curator's blog
+              </a>
+            </div>
+          )}
+
           {hasMeaningfulNotes(talk.notes) && (
             <div className="mt-8">
               <h2 className="text-xl font-semibold text-gray-900 mb-4">Key Notes</h2>

--- a/src/hooks/useTalks.ts
+++ b/src/hooks/useTalks.ts
@@ -17,6 +17,7 @@ export interface AirtableItem {
   resource_type: string;
   year: number;
   conference_name: string;
+  blog_url?: string;
 }
 
 const MAX_RETRIES = 3;

--- a/src/types/talks.ts
+++ b/src/types/talks.ts
@@ -11,4 +11,5 @@ export interface Talk {
   year?: number;  // Optional field for the talk's year
   conference_name?: string;  // Optional field for conference name
   format?: 'talk' | 'podcast' | 'article';
+  blog_url?: string;
 }

--- a/src/utils/talks.ts
+++ b/src/utils/talks.ts
@@ -30,7 +30,8 @@ export function transformAirtableItemToTalk(item: AirtableItem): Talk {
     notes: hasMeaningfulNotes(item.notes) ? item.notes : undefined,
     year: item.year,
     conference_name: item.conference_name,
-    format
+    format,
+    blog_url: item.blog_url || undefined
   };
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for displaying a curator's blog link in the talk detail view when a blog URL is available.

## Key Changes
- **Type definitions**: Added optional `blog_url` field to `Talk` interface and `AirtableItem` interface
- **Data transformation**: Updated `transformAirtableItemToTalk()` to map the `blog_url` field from Airtable items
- **UI component**: Added a conditional blog link section in `TalkDetail` component that displays when `blog_url` is present, with proper accessibility attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- **Tests**: Added comprehensive test coverage for the blog link feature, including cases for when the URL is present, undefined, or empty

## Implementation Details
- The blog link is rendered as an inline-flex element with a memo emoji icon and "Mentioned in curator's blog" text
- The link opens in a new tab with security attributes to prevent window.opener access
- The feature gracefully degrades when `blog_url` is absent or empty - the link section simply won't render
- All three test cases verify proper rendering behavior and link attributes

https://claude.ai/code/session_013v9dNvgBoYTCrZbFrqPbyP